### PR TITLE
Various typos

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -58,7 +58,7 @@ if mode == "print":
     for dev, direction, string in protocol:
         print("%s %s%s" % (dev, "> " if direction == "0" else "  < ", repr(string)[1:-1]))
 
-elif mode == "extract":
+elif mode == "dump":
     start_address = None
     prev_address = None
     for dev, direction, string in protocol:

--- a/hx870dat.bt
+++ b/hx870dat.bt
@@ -4,11 +4,11 @@
 //      File: hx870dat.bt
 //   Authors: Christiane Ruetten
 //    E-Mail: cr@23bit.net
-//   Version: 0.1a
+//   Version: 0.1.1a
 //   Purpose: Parsing Standard Horizon HX870 DAT files
 //  Category: HF Radio
 // File Mask: *.dat
-//  ID Bytes: 03 67 01 00 00 00 00 00
+//  ID Bytes: 03 67
 //   History: Based on https://johannessen.github.io/hx870/
 //------------------------------------------------
 
@@ -21,7 +21,7 @@ BigEndian();
 
 // Magic Bytes -----------------------------------
 FSeek(0x0000);
-uint16 MagicPrefix <bgcolor=0xff00cc00>;  // always 0x0361 (871)
+uint16 MagicPrefix <bgcolor=0xff00cc00>;  // always 0x0367 (871)
 
 
 // 0002 Radio Status -----------------------------
@@ -56,7 +56,7 @@ enum <ubyte> _MultiWatch { MW_DUAL, MW_TRIPLE };
 enum <ubyte> _ScanType { ST_MEMORY, ST_PRIORITY };
 enum <ubyte> _EmergencyLED { EL_CONTINUOUS, EL_SOS, EL_BLINK1, EL_BLINK2, EL_BLINK3 };
 enum <ubyte> _WaterHazardLED { WH_OFF, WH_ON, WH_ON_POWER_ON };
-enum <ubyte> _Lamp { L_OFF, L_3S, L_5S, L_10S, L_20S, L_30S, L_CONTINUOUS };
+enum <ubyte> _Lamp { L_OFF, L_3S, L_5S, L_10S, L_CONTINUOUS, L_20S, L_30S };
 enum <ubyte> _AFPitchCONT { A_NORMAL, A_HIGH_LOW_CUT, A_HIGH_LOW_BOOST, A_LOW_BOOST, A_HIGH_BOOST };
 enum <ubyte> _BatterySave { BS_OFF, BS_50, BS_70, BS_80, BS_90 };
 enum <ubyte> _VOXDelayTime { V_0_5S, V_1S, V_1_5S, V_2S, V_3S };
@@ -94,9 +94,9 @@ struct _RadioConfiguration {  // start: 0020
     // Channels Setup continued
     _OffOn VOX;
     ubyte VOXLevel;  // 0..4
-    ubyte _unknown0044 <format=hex, bgcolor=cBlack>;  // always 00
     _VOXDelayTime VOXDelayTime;
     _OffOn NoiseCancelRx;
+    ubyte NoiseCancelRxLevel;  // 0..3
     _OffOn NoiseCancelTx;
     ubyte _unknown0046 <format=hex, bgcolor=cBlack>;  // always 00 
     ubyte _unused0047[3] <format=hex>;  // always ff

--- a/hxtool/device.py
+++ b/hxtool/device.py
@@ -81,7 +81,7 @@ def enumerate_model(hx_device) -> list:
 
 class HX870(object):
     """
-    Device object for Standard Horizon HX890 maritime radios
+    Device object for Standard Horizon HX870 maritime radios
     """
     handle = "HX870"
     brand = "Standard Horizon"

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(
               'hx890', 'hx890e', 'firmware', 'flashing', 'mmsi', 'atis'],
     author='Christiane Ruetten',
     author_email='cr@23bit.net',
-    url='https://github.com/cr/pyhx870',
-    download_url='https://github.com/cr/pyhx870/archive/master.tar.gz',
+    url='https://github.com/cr/hx870',
+    download_url='https://github.com/cr/hx870/archive/master.tar.gz',
     license='GPLv3',
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,  # See MANIFEST.in


### PR DESCRIPTION
Hi cr,

I have modified `pyhx870` to be a bit more useful for myself, and conceivably for others as well. Obviously I have no idea if any of this is even roughly in the direction into which you want to take this tool. Feel free to let me know what you think if you have the time.

A few brief notes:

- As mentioned by email, I am not fully fluent in Python. First and foremost, therefore, it was my intention to provide some sort of Python-free interface to this tool, enabling me to read and write from and to the device using the shell command line. The two simple CLI scripts `read-config.py` and `write-config.py` accomplish that. Both are based on `pyhx870/main.py`.

  (Am I correct in assuming that at this point, `pyhx870/main.py` no longer serves any purpose and could be removed?)

- After cloning `pyhx870` for the first time, I struggled for a while with installing the required modules, until I found out about `pip` and `setup.py`. (Yes, it’s been a looong time since I used Python before.) Other noobs might benefit from some kind of brief “installation instructions” in the readme file. I haven’t yet drafted those, as I wasn’t sure whether you’d appreciate me changing the readme.

- It took some time to sort out which parts of the HX870 class dealt with low-level protocol stuff and which parts were a high-level API, so I took the liberty of separating those parts into two different classes. I guess it’d be nicer if the protocol implementation details were not inherited by the object the client uses directly, but changing that would have meant modifying the API, which I tried to avoid out of fear for breaking other clients.

- Some more fields are now documented on the HTML page at <https://github.com/johannessen/hx870>. Since I don’t have 010 Editor, I didn’t update your template.

Cheers,
Arne