### PR TITLE
Adding simulator stub

### DIFF
--- a/hxtool/__init__.py
+++ b/hxtool/__init__.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 def get(args):
     """Select a single device according to arguments"""
-    devices = enumerate(force_model=args.model, force_device=args.tty)
+    devices = enumerate(force_model=args.model, force_device=args.tty, add_simulator=args.simulator)
 
     if len(devices) == 0:
         logger.critical("No device detected. Connect device or try specifying --tty")

--- a/hxtool/cli/devices.py
+++ b/hxtool/cli/devices.py
@@ -14,7 +14,7 @@ class DevicesCommand(CliCommand):
     help = "enumerate detected devices"
 
     def run(self):
-        devices = enumerate()
+        devices = enumerate(add_simulator=self.args.simulator)
         if len(devices) > 0:
             for device in devices:
                 mode = "unknown mode (BE CAREFUL)"
@@ -24,7 +24,7 @@ class DevicesCommand(CliCommand):
                     mode = "CP mode"
                 if not device.comm.hx_hardware:
                     mode = "unknown hardware (BE CAREFUL)"
-                print(f"[{devices.index(device)}]\t{device.brand}\t{device.model}\t{mode}")
+                print(f"[{devices.index(device)}]\t{device.tty}\t{device.brand}\t{device.model}\t{mode}")
             return 0
 
         else:

--- a/hxtool/protocol.py
+++ b/hxtool/protocol.py
@@ -169,8 +169,7 @@ class GenericHXProtocol(object):
     def cmd_mode(self):
         logger.debug("Sending command mode request")
         self.write(b"P")
-        self.write(b"0")
-        self.write(Message("ACMD:002"))
+        self.write(Message("0ACMD:002"))
 
     def sync(self, flush_output=True, flush_input=True):
         if flush_output:
@@ -262,6 +261,8 @@ class GenericHXProtocol(object):
             if r.type != "#CMDOK":
                 raise ProtocolError("Device did not acknowledge status request")
             r = self.receive()  # expect #CEPSD
+            if r.type != "#CEPSD":
+                raise ProtocolError("Device did not return status")
             radio_status = r.args[0]
             if radio_status != "00":
                 logger.debug("Waiting for radio, state=%s" % radio_status)

--- a/hxtool/simulator.py
+++ b/hxtool/simulator.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+from binascii import hexlify
+from os import ttyname, read, write, set_blocking
+from pty import openpty
+from threading import Event, Thread
+from time import sleep, time
+
+from .protocol import Message
+
+logger = logging.getLogger(__name__)
+
+
+class HXSimulator(Thread):
+
+    instances = []
+
+    @classmethod
+    def register(cls, instance):
+        cls.instances.append(instance)
+
+    @classmethod
+    def stop_instances(cls):
+        for instance in cls.instances:
+            instance.stop()
+
+    @classmethod
+    def join_instances(cls):
+        for instance in cls.instances:
+            instance.join()
+
+    def __init__(self, mode: str, config: bytearray or None = None,
+                 loop_delay: float = 1.0 / 9600, nmea_delay: float = 3.0):
+        super().__init__()
+        assert mode in ["CP", "NMEA"], "Invalid simulator mode"
+        self.mode = mode
+        self.c = config or bytearray(b"\xff" * 0x8000)
+        self.master, self.slave = openpty()
+        self.tty = ttyname(self.slave)
+        self.stop_running = Event()
+        self.loop_delay = loop_delay
+        self.nmea_delay = nmea_delay
+        HXSimulator.instances.append(self)
+        # FIXME: This will fail on Windows (probably on import)
+        set_blocking(self.master, False)
+        self.ignore_cmdok = False
+
+    def run(self):
+        if self.mode == "NMEA":
+            self.__run_nmea_mode()
+        elif self.mode == "CP":
+            self.__run_cp_mode()
+        else:
+            raise Exception("Invalid simulator mode")
+
+    def stop(self):
+        self.stop_running.set()
+
+    def __run_nmea_mode(self):
+        logger.debug("Starting simulator thread in NMEA mode")
+        message = b""
+        next_message_time = time() + self.nmea_delay
+        while not self.stop_running.wait(self.loop_delay):
+            try:
+                b = read(self.master, 1)
+            except BlockingIOError:
+                b = b""
+            if len(b) > 0:
+                # We have input and all NMEA messages start with $
+                if len(message) > 0:
+                    # If we are receiving part of a message, append
+                    # input to message buffer until newline received.
+                    message += b
+                    if message.endswith(b"\r\n"):
+                        # If line is complete, process message
+                        self.__process_nmea_message(message)
+                        message = b""
+                elif b == b"$":
+                    message = b
+                elif b == b"P":
+                    # Reply with P to P to signal NMEA mode
+                    logger.debug("NMEA simulator responding to ping")
+                    write(self.master, b"P")
+                else:
+                    # Ignore all other bytes outside of messages
+                    logger.debug(f"NMEA simulator ignoring unexpected input {b}")
+            else:
+                # No input, so check whether it's time to send
+                # a dummy NMEA message.
+                now = time()
+                if now >= next_message_time:
+                    write(self.master, b"$GPLL,,,,\r\n")
+                    next_message_time = now + self.nmea_delay
+
+        logger.debug("NMEA simulator thread finished")
+
+    def __process_nmea_message(self, msg):
+        logger.debug(f"NMEA simulator processing message {msg}")
+
+    def __run_cp_mode(self):
+        logger.debug("Starting simulator thread in CP mode")
+        message = b""
+        while not self.stop_running.wait(self.loop_delay):
+            try:
+                b = read(self.master, 1)
+            except BlockingIOError:
+                b = b""
+            if len(b) > 0:
+                logger.debug(f"CP mode got {b}")
+                # We have input and all NMEA messages start with $
+                if len(message) > 0:
+                    # If we are receiving part of a message, append
+                    # input to message buffer until newline received.
+                    message += b
+                    if message.endswith(b"\r\n"):
+                        # If line is complete, process message
+                        self.__process_cp_message(message)
+                        message = b""
+                elif b == b"#" or b == b"0":
+                    # Beginning of #... or 0ACMD:002 message?
+                    message = b
+                elif b == b"?":
+                    # Reply with @ to ? to signal CP mode
+                    logger.debug("CP simulator responding to ping")
+                    write(self.master, b"@")
+                else:
+                    # Ignore all other bytes outside of messages
+                    logger.debug(f"CP simulator ignoring unexpected input {b}")
+
+        logger.debug("CP simulator thread finished")
+
+    def __process_cp_message(self, msg):
+        logger.debug(f"CP simulator processing message {msg}")
+        msg = Message(parse=msg)
+        if msg.type == "#CMDOK":
+            if self.ignore_cmdok:
+                self.ignore_cmdok = False
+            else:
+                write(self.master, bytes(Message("#CMDOK")))
+        elif msg.type == "0ACMD:002":
+            pass
+        elif msg.type == "#CMDSY":
+            write(self.master, bytes(Message("#CMDOK")))
+        elif msg.type == "#CVRRQ":
+            write(self.master, bytes(Message("#CMDOK")))
+            write(self.master, bytes(Message("#CVRDQ", ["23.42"])))
+        elif msg.type == "#CEPSR":
+            write(self.master, bytes(Message("#CMDOK")))
+            write(self.master, bytes(Message("#CEPSD", ["00"])))
+            self.ignore_cmdok = True
+        elif msg.type == "#CEPRD":
+            write(self.master, bytes(Message("#CMDOK")))
+            offset = int(msg.args[0], 16)
+            size = int(msg.args[1], 16)
+            data = hexlify(self.c[offset:offset + size]).decode("ascii")
+            write(self.master, bytes(Message("#CEPDT", [msg.args[0], msg.args[1], data])))
+            # Ignore next CMDOK
+            self.ignore_cmdok = True
+        else:
+            write(self.master, bytes(Message("#CMDER")))

--- a/tests/simulator_test.py
+++ b/tests/simulator_test.py
@@ -1,0 +1,74 @@
+import pytest
+from serial import Serial
+from sys import platform
+
+from hxtool import simulator
+
+# The simulator doesn't work on Windows, so skip test if running on Windows
+if platform.startswith("win"):
+    pytest.skip("Skipping simulator tests on Windows", allow_module_level=True)
+
+
+@pytest.fixture(name="cp_sim")
+def fixture_cp_simulator():
+    s = simulator.HXSimulator(mode="CP", loop_delay=0.01)
+    yield s
+    s.stop()
+    s.join(timeout=1)
+
+
+@pytest.fixture(name="nmea_sim")
+def fixture_nmea_simulator():
+    s = simulator.HXSimulator(mode="NMEA", loop_delay=0.01, nmea_delay=0.2)
+    yield s
+    s.stop()
+    s.join(timeout=1)
+
+
+def test_nmea_simulator(nmea_sim):
+    nmea_sim.start()
+    s = Serial(nmea_sim.tty, timeout=1.5)
+
+    # Simulator should respond with P iff we send it a P
+    s.flushInput()
+    s.flushOutput()
+    s.write(b"FOOP?IGNOREP")
+    assert s.read(1) == b"P", "Simulator signals NMEA mode"
+    assert s.read(1) == b"P", "Simulator signals NMEA mode twice"
+
+    # Simulator should be sending NMEA dummy messages
+    m = s.readline()
+    assert m.startswith(b"$GPLL") and m.endswith(b"\r\n"), "Simulator sends NMEA message"
+    m = s.readline()
+    assert m.startswith(b"$GPLL") and m.endswith(b"\r\n"), "Simulator keeps sending NMEA messages"
+    m = s.readline()
+    assert m.startswith(b"$GPLL") and m.endswith(b"\r\n"), "Simulator keeps sending NMEA messages still"
+
+    # Simulator should still respond with P iff we send it a P
+    s.write(b"FOOP?IGNORE")
+    assert s.read(1) == b"P", "Simulator still signals NMEA mode"
+
+
+def test_cp_simulator(cp_sim):
+    cp_sim.start()
+    s = Serial(cp_sim.tty, timeout=1.5)
+
+    # Simulator should respond with @ iff we send it a ?
+    s.flushInput()
+    s.flushOutput()
+    s.write(b"FOOP?IGNORE?")
+    assert s.read(1) == b"@", "Simulator signals CP mode"
+    assert s.read(1) == b"@", "Simulator signals CP mode twice"
+
+    # FIXME: Dummy simulator responds with #CMDER to every message
+    s.write(b"#CMDSY\r\n")
+    m = s.readline()
+    assert m == b"#CMDOK\r\n", "CP simulator responds like a dummy FIXME"
+
+    s.write(b"#CMDSY\r\n")
+    m = s.readline()
+    assert m == b"#CMDOK\r\n", "CP simulator responds like a dummy again FIXME"
+
+    # Simulator should still respond with @ iff we send it a ?
+    s.write(b"FOOP?IGNORE")
+    assert s.read(1) == b"@", "Simulator still signals CP mode"


### PR DESCRIPTION
Try `hxtool --simulator devices`. The simulator has a rudimentary command parser that supports config reads in CP mode, and it dumps fake NMEA sentences when in NMEA mode.

Implementation is rather elegantly as pseudo serial device, enabling full-stack testing with just few additional code.