### PR TITLE
Adding log status info, improving stability when log full

### DIFF
--- a/hxtool/config.py
+++ b/hxtool/config.py
@@ -48,7 +48,6 @@ class GenericHXConfig(object):
             logger.info(f"0 / {bytes_to_go} bytes (0%)")
         self.p.write_config_memory(0x0002, data[0x0002:0x000f])
         self.p.write_config_memory(0x0010, data[0x0010:0x0040])
-        bytes_done = 0x40
         for offset in range(0x0040, 0x7fc0, 0x40):
             if progress:
                 percent_done = int(100.0 * offset / bytes_to_go)

--- a/hxtool/memory.py
+++ b/hxtool/memory.py
@@ -83,17 +83,16 @@ def unpack_log_line(data: bytes):
         raise protocol.ProtocolError(f"Log line checksum error: {hexlify(data).decode('ascii')}, expected {hex(chk)}")
 
     # tz_code is 02 if log was captured in UTC mode, 04 if localtime mode.
-    # However, timezone offset is not stored anywhere and timestamp is always UTC.
+    # However, timezone offset is not stored anywhere in log and timestamp is always UTC.
 
     return {
         "utc_time": datetime.datetime.utcfromtimestamp(timestamp),
         "tz_code": tz_code,
         "latitude": latitude,
         "longitude": longitude,
-        "altitude": altitude,
-        "speed": speed,
-        "heading": heading,
-        "checksum": checksum
+        "altitude": altitude,  # FIXME: Unit is always meters?
+        "speed": speed,  # FIXME: Is this really speed? What unit is it?
+        "heading": heading
     }
 
 # Snippets for waypoint export

--- a/hxtool/nmea.py
+++ b/hxtool/nmea.py
@@ -9,13 +9,6 @@ from .protocol import Message, GenericHXProtocol, ProtocolError
 logger = getLogger(__name__)
 
 
-def receive_until(p: GenericHXProtocol, stop: str) -> Message:
-    while True:
-        r = p.receive()
-        if r.type == stop:
-            return r
-
-
 class GenericNMEAProtocol(object):
 
     def __init__(self, protocol: GenericHXProtocol):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 PACKAGE_NAME = 'hxtool'
-PACKAGE_VERSION = '0.3.0a'
+PACKAGE_VERSION = '0.3.0a2'
 
 INSTALL_REQUIRES = [
     'coloredlogs',


### PR DESCRIPTION
Finally reverse-engineered some of the LogStatus response, resulting in improved log status reporting.

This also fixes random crashes when the log is full. It now properly handles full log conditions when the radio starts randomly spurting "FULL_LOG" warnings, disrupting regular protocol flow. The new code knows how to ignore those.