### PR TITLE
Nav subcommand

### DIFF
--- a/hxtool/cli/__init__.py
+++ b/hxtool/cli/__init__.py
@@ -7,6 +7,7 @@ from . import devices
 from . import gpslog
 from . import id
 from . import info
+from . import nav
 from . import nmea
 
 __all__ = [
@@ -17,5 +18,6 @@ __all__ = [
     "gpslog",
     "id",
     "info",
+    "nav",
     "nmea"
 ]

--- a/hxtool/cli/nav.py
+++ b/hxtool/cli/nav.py
@@ -153,20 +153,28 @@ def write_gpx(nav_data: dict,  file_name: str) -> int:
     gpx = gpxpy.gpx.GPX()
 
     for point in nav_data["waypoints"]:
+        comment = "id {}".format(point["id"])
+        if point["mmsi"] is not None:
+            comment += "; position received from MMSI {}".format(point["mmsi"])
         p = gpxpy.gpx.GPXWaypoint(
             latitude=point["latitude_decimal"],
             longitude=point["longitude_decimal"],
             name=point["name"],
+            comment=comment,
         )
         gpx.waypoints.append(p)
-    
+
     for route in nav_data["routes"]:
         r = gpxpy.gpx.GPXRoute(name=route["name"])
         for point in route["points"]:
+            comment = "id {}".format(point["id"])
+            if point["mmsi"] is not None:
+                comment += "; position received from MMSI {}".format(point["mmsi"])
             p = gpxpy.gpx.GPXRoutePoint(
                 latitude=point["latitude_decimal"],
                 longitude=point["longitude_decimal"],
                 name=point["name"],
+                comment=comment,
             )
             r.points.append(p)
         gpx.routes.append(r)

--- a/hxtool/cli/nav.py
+++ b/hxtool/cli/nav.py
@@ -19,9 +19,18 @@ class NavCommand(CliCommand):
     @staticmethod
     def setup_args(parser) -> None:
         parser.add_argument("-g", "--gpx",
-                            help="file name for GPX export",
+                            help="name of GPX file",
                             type=abspath,
                             action="store")
+        parser.add_argument("-d", "--dump",
+                            help="read nav data from device and write to file",
+                            action="store_true")
+        parser.add_argument("-f", "--flash",
+                            help="read nav data from file and write to device",
+                            action="store_true")
+        parser.add_argument("-e", "--erase",
+                            help="erase existing nav data from device",
+                            action="store_true")
 
     def run(self):
 
@@ -34,16 +43,23 @@ class NavCommand(CliCommand):
             return 10
 
         result = 0
+        
+        if self.args.dump:
+            result = max(self.dump(hx), result)
 
-        if self.args.gpx:
-                logger.info("Reading nav data from handset")
-                raw_nav_data = hx.config.read_nav_data(True)
-
-        if self.args.gpx:
-            logger.info("Exporting GPX nav data to `%s`", self.args.gpx)
-            result = max(write_gpx(raw_nav_data, self.args.gpx), result)
+        if self.args.flash or self.args.erase:
+            raise NotImplementedError
 
         return result
+
+
+    def dump(self, hx):
+        if self.args.gpx:
+            logger.info("Reading nav data from handset")
+            raw_nav_data = hx.config.read_nav_data(True)
+            logger.info("Writing GPX nav data to `{}`".format(self.args.gpx))
+            return write_gpx(raw_nav_data, self.args.gpx)
+        return 0
 
 
 def write_gpx(nav_data: dict,  file_name: str) -> int:

--- a/hxtool/cli/nav.py
+++ b/hxtool/cli/nav.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+from binascii import hexlify
+import gpxpy
+import gpxpy.gpx
+from logging import getLogger
+from os.path import abspath
+
+import hxtool
+from .base import CliCommand
+from hxtool.memory import unpack_log_line
+
+logger = getLogger(__name__)
+
+
+class NavCommand(CliCommand):
+
+    name = "nav"
+    help = "dump or flash navigation data (waypoints and routes)"
+
+    @staticmethod
+    def setup_args(parser) -> None:
+        parser.add_argument("-g", "--gpx",
+                            help="file name for GPX export",
+                            type=abspath,
+                            action="store")
+
+    def run(self):
+
+        hx = hxtool.get(self.args)
+        if hx is None:
+            return 10
+
+        if not hx.comm.cp_mode:
+            logger.critical("For navigation data functions, device must be in CP mode (MENU + ON)")
+            return 10
+
+        result = 0
+
+        if self.args.gpx or self.args.raw:
+                logger.info("Reading nav data from handset")
+                raw_nav_data = hx.config.read_waypoints()
+                logger.info(f"Received {len(raw_nav_data)} bytes of raw nav data from handset")
+        else:
+            raw_nav_data = None
+
+        if self.args.gpx:
+            logger.info("Exporting GPX nav data to `%s`", self.args.gpx)
+            result = max(write_gpx(raw_nav_data, self.args.gpx), result)
+
+        return result
+
+
+def write_gpx(waypoints: bytes,  file_name: str) -> int:
+    if waypoints is None:
+        logger.warning("No waypoints in device. Not writing empty GPX file")
+        return 0
+
+    gpx = gpxpy.gpx.GPX()
+
+    for point in waypoints:
+        p = gpxpy.gpx.GPXWaypoint(
+            latitude=point["latitude_decimal"],
+            longitude=point["longitude_decimal"],
+            name=point["name"],
+        )
+        gpx.waypoints.append(p)
+
+    with open(file_name, "w") as f:
+        f.write(gpx.to_xml(version="1.1"))
+
+    return 0

--- a/hxtool/config.py
+++ b/hxtool/config.py
@@ -14,6 +14,12 @@ class GenericHXConfig(object):
     def __init__(self, protocol: GenericHXProtocol):
         self.p = protocol
 
+    def limits(self):
+        return {
+            "waypoints": 200,
+            "routes": 20,
+        }
+
     def config_read(self, progress=False):
         config_data = b''
         bytes_to_go = 0x8000

--- a/hxtool/memory.py
+++ b/hxtool/memory.py
@@ -52,7 +52,7 @@ def pack_waypoint(wp):
     lat_dir = m[2]
     lat_min = float(m[3])
     lat_minstr = ("%.04f" % lat_min).replace(".", "").zfill(6)
-    lat_hex = "FF%02d%s%s" % (lat_deg, lat_minstr, lat_dir)
+    lat_hex = "FF%02d%s%02x" % (lat_deg, lat_minstr, ord(lat_dir))
     if len(lat_hex) != 12:
         raise protocol.ProtocolError("Invalid waypoint latitude format")
 
@@ -63,12 +63,12 @@ def pack_waypoint(wp):
     lon_dir = m[2]
     lon_min = float(m[3])
     lon_minstr = ("%.04f" % lon_min).replace(".", "").zfill(6)
-    lon_hex = "%04d%s%s" % (lon_deg, lon_minstr, lon_dir)
+    lon_hex = "%04d%s%02x" % (lon_deg, lon_minstr, ord(lon_dir))
     if len(lon_hex) != 12:
         raise protocol.ProtocolError("Invalid waypoint longitude format")
 
-    wp_data = b'\xff'*4 + unhexlify(lat_hex) + lat_dir.encode("ascii")
-    wp_data += unhexlify(lon_hex) + lon_dir.encode("ascii")
+    wp_data = b'\xff'*4
+    wp_data += unhexlify(lat_hex) + unhexlify(lon_hex)
     wp_data += wp["name"].encode("ascii")[:15].ljust(15, b'\xff')
     wp_data += unhexlify("%02x" % wp["id"])  # TODO: There must be an elegant way
     if len(wp_data) != 32:

--- a/hxtool/memory.py
+++ b/hxtool/memory.py
@@ -28,12 +28,17 @@ def unpack_waypoint(data):
     lon_min = int(lon_str[4:10]) / 10000.0
     lon_dir = chr(data[15])
 
+    wp_lat_decimal = { "S": -1.0, "N": 1.0 }[lat_dir] * lat_deg + lat_min / 60.0
+    wp_lon_decimal = { "W": -1.0, "E": 1.0 }[lon_dir] * lon_deg + lon_min / 60.0
+
     wp_latitude = "%d%s%3.4f" % (lat_deg, lat_dir, lat_min)
     wp_longitude = "%d%s%3.4f" % (lon_deg, lon_dir, lon_min)
 
     return {
         "id": wp_id,
         "name": wp_name,
+        "latitude_decimal": wp_lat_decimal,
+        "longitude_decimal": wp_lon_decimal,
         "latitude": wp_latitude,
         "longitude": wp_longitude
     }

--- a/hxtool/memory.py
+++ b/hxtool/memory.py
@@ -22,9 +22,9 @@ def unpack_waypoint(data):
     if wp_mmsi == "fffffffff":
         wp_mmsi = None
 
-    lat_str = hexlify(data[4:9])[1:]
-    lat_deg = int(lat_str[1:3])
-    lat_min = int(lat_str[3:9]) / 10000.0
+    lat_str = hexlify(data[5:9])
+    lat_deg = int(lat_str[0:2])
+    lat_min = int(lat_str[2:8]) / 10000.0
     lat_dir = chr(data[9])
 
     lon_str = hexlify(data[10:15])

--- a/hxtool/memory.py
+++ b/hxtool/memory.py
@@ -77,6 +77,20 @@ def pack_waypoint(wp):
     return wp_data
 
 
+def unpack_route(data):
+    if data[0x10] == 255:
+        return None
+    name = data[0:0x10].rstrip(b'\xff').decode("ascii")
+    waypoint_ids = []
+    for i in range(0x10, 0x20):
+        if data[i] != 255:
+            waypoint_ids.append(data[i])
+    return {
+        "name": name,
+        "points": waypoint_ids,
+    }
+
+
 region_code_map = {
     0: "INTERNATIONAL",
     1: "UNITED KINGDOM",

--- a/hxtool/memory.py
+++ b/hxtool/memory.py
@@ -19,7 +19,7 @@ def unpack_waypoint(data):
     wp_name = data[16:31].rstrip(b'\xff').decode("ascii")
 
     lat_str = hexlify(data[4:9])[1:]
-    lat_deg = int(lat_str[0:3])
+    lat_deg = int(lat_str[1:3])
     lat_min = int(lat_str[3:9]) / 10000.0
     lat_dir = chr(data[9])
 
@@ -47,7 +47,7 @@ def pack_waypoint(wp):
     lat_dir = m[2]
     lat_min = float(m[3])
     lat_minstr = ("%.04f" % lat_min).replace(".", "").zfill(6)
-    lat_hex = "F%03d%s%s" % (lat_deg, lat_minstr, lat_dir)
+    lat_hex = "FF%02d%s%s" % (lat_deg, lat_minstr, lat_dir)
     if len(lat_hex) != 12:
         raise protocol.ProtocolError("Invalid waypoint latitude format")
 


### PR DESCRIPTION
Replacing all waypoints on the device with `--flash --erase` already works fine. Appending new waypoints without `--erase`ing the existing data in the device will be added soon-ish.

Routes are also supported, but round-trip HX870→GPX→HX870 doesn’t work so well, as already discussed in https://github.com/cr/hx870/issues/30#issuecomment-546603010.