### PR TITLE
Prepare to support other device models

### DIFF
--- a/hxtool/cli/info.py
+++ b/hxtool/cli/info.py
@@ -4,7 +4,6 @@ from logging import getLogger
 
 import hxtool
 from .base import CliCommand
-from ..memory import region_code_map
 
 logger = getLogger(__name__)
 
@@ -36,16 +35,15 @@ class InfoCommand(CliCommand):
             logger.warning(f"Flash ID mismatch. {fid} not in {hx.flash_id}")
         print(f"Flash ID:\t{fid}")
 
-        region_code = hx.config.read_region()
-        region = region_code_map[region_code]
+        region, region_code = hx.config.read_region()
         print(f"Region:\t{region} [{region_code:02x}]")
 
         mmsi, mmsi_status = hx.config.read_mmsi()
         print(f"MMSI:\t{mmsi}")
         print(f"MMSI status:\t{mmsi_status}")
 
-        atis_enabled_code = hx.config.read_atis_enabled()
-        atis_enabled = "ENABLED" if atis_enabled_code == 1 else "DISABLED"
+        atis_enabled, atis_enabled_code = hx.config.read_atis_enabled()
+        atis_enabled = "ENABLED" if atis_enabled else "DISABLED"
         print(f"ATIS function:\t{atis_enabled} [{atis_enabled_code:02x}]")
 
         atis, atis_status = hx.config.read_atis()

--- a/hxtool/config.py
+++ b/hxtool/config.py
@@ -12,8 +12,21 @@ logger = getLogger(__name__)
 class GenericHXConfig(object):
 
     CONFIG_MAGIC = [0xff, 0xff]
-    CONFIG_SIZE = 0x8000
     FLASH_ID = ["AM000A"]
+
+    CHUNK_SIZE = 0x40
+    CONFIG_SIZE = 0x8000
+    PROGRESS_LOG_AT = 0x1000
+
+    MMSI_OFFSET = 0x00b0
+    ATIS_CODE_OFFSET = 0x00b6
+    ATIS_ENABLED_OFFSET = 0x00a2
+    FLASH_ID_OFFSET = 0x0100
+    REGION_CODE_OFFSET = 0x010f
+    WAYPOINT_OFFSET = 0x4300
+
+    REGION_CODE_US = 0xff
+    WAYPOINT_COUNT = 200
 
     def __init__(self, protocol: GenericHXProtocol):
         self.p = protocol
@@ -21,61 +34,65 @@ class GenericHXConfig(object):
     def config_read(self, progress=False):
         config_data = b''
         bytes_to_go = self.CONFIG_SIZE
-        for offset in range(0x0000, self.CONFIG_SIZE, 0x40):
+        for offset in range(0x0000, self.CONFIG_SIZE, self.CHUNK_SIZE):
             if progress:
                 percent_done = int(100.0 * offset / bytes_to_go)
-                if offset % 0x1000 == 0:
+                if offset % self.PROGRESS_LOG_AT == 0:
                     logger.info(f"{offset} / {bytes_to_go} bytes ({percent_done}%)")
-            config_data += self.p.read_config_memory(offset, 0x40)
+            config_data += self.p.read_config_memory(offset, self.CHUNK_SIZE)
         if progress:
             logger.info(f"{bytes_to_go} / {bytes_to_go} bytes (100%)")
         return config_data
 
-    def config_write(self, data, check_region=True, progress=False):
-        bytes_to_go = len(data)
-        if bytes_to_go != self.CONFIG_SIZE:
+    def _config_write_precheck(self, data, check_region):
+        if len(data) != self.CONFIG_SIZE:
             raise ProtocolError("Unexpected config data size")
         magic = self.p.read_config_memory(0x0000, 2)
         magic_end = self.p.read_config_memory(self.CONFIG_SIZE-2, 2)
         if magic != data[:2] or magic_end != data[-2:]:
             raise ProtocolError("Unexpected config magic in device")
-        region = self.p.read_config_memory(0x010f, 1)
-        region_is_us = region == b'\xff'
-        data_is_us = data[0x010f] == 0xff
+        region = ord(self.p.read_config_memory(self.REGION_CODE_OFFSET, 1))
+        region_is_us = region == self.REGION_CODE_US
+        data_is_us = data[self.REGION_CODE_OFFSET] == self.REGION_CODE_US
         if region_is_us != data_is_us:
             if check_region:
                 logger.error("Region mismatch")
                 raise ProtocolError("Region mismatch")
             logger.warning("Ignoring region mismatch. Flashing anyway")
 
+    def config_write(self, data, check_region=True, progress=False):
+        self._config_write_precheck(data, check_region)
+        bytes_to_go = len(data)
         if progress:
             logger.info(f"0 / {bytes_to_go} bytes (0%)")
         self.p.write_config_memory(0x0002, data[0x0002:0x000f])
-        self.p.write_config_memory(0x0010, data[0x0010:0x0040])
-        for offset in range(0x0040, self.CONFIG_SIZE-0x40, 0x40):
+        self.p.write_config_memory(0x0010, data[0x0010:self.CHUNK_SIZE])
+        last_chunk = self.CONFIG_SIZE - self.CHUNK_SIZE
+        for offset in range(self.CHUNK_SIZE, last_chunk, self.CHUNK_SIZE):
             if progress:
                 percent_done = int(100.0 * offset / bytes_to_go)
-                if offset % 0x1000 == 0:
+                if offset % self.PROGRESS_LOG_AT == 0:
                     logger.info(f"{offset} / {bytes_to_go} bytes ({percent_done}%)")
-            self.p.write_config_memory(offset, data[offset:offset+0x40])
-        self.p.write_config_memory(self.CONFIG_SIZE-0x40, data[self.CONFIG_SIZE-0x40:self.CONFIG_SIZE-2])
+            self.p.write_config_memory(offset, data[offset:offset+self.CHUNK_SIZE])
+        self.p.write_config_memory(last_chunk, data[last_chunk:-2])
         if progress:
             logger.info(f"{bytes_to_go} / {bytes_to_go} bytes (100%)")
 
     def read_waypoints(self):
         wp_data = b''
-        for address in range(0x4300, 0x5c00, 0x40):
-            wp_data += self.p.read_config_memory(address, 0x40)
+        waypoint_end_offset = self.WAYPOINT_OFFSET + self.WAYPOINT_COUNT * 32
+        for address in range(self.WAYPOINT_OFFSET, waypoint_end_offset, self.CHUNK_SIZE):
+            wp_data += self.p.read_config_memory(address, self.CHUNK_SIZE)
         wp_list = []
-        for wp_id in range(1, 201):
-            offset = (wp_id - 1) * 32
+        for wp_index in range(0, self.WAYPOINT_COUNT):
+            offset = wp_index * 32
             wp = unpack_waypoint(wp_data[offset:offset+32])
             if wp is not None:
                 wp_list.append(wp)
         return wp_list
 
     def read_mmsi(self):
-        data = hexlify(self.p.read_config_memory(0x00b0, 6)).decode().upper()
+        data = hexlify(self.p.read_config_memory(self.MMSI_OFFSET, 6)).decode().upper()
         mmsi = data[0:9]
         status = data[10:12]
         return mmsi, status
@@ -97,10 +114,10 @@ class GenericHXConfig(object):
         if status.upper() not in ["00", "01", "02", "FF"]:
             raise ProtocolError("Invalid MMSI status")
         data = unhexlify(mmsi + status)
-        self.p.write_config_memory(0x00b0, data)
+        self.p.write_config_memory(self.MMSI_OFFSET, data)
 
     def read_atis(self):
-        data = hexlify(self.p.read_config_memory(0x00b6, 6)).decode().upper()
+        data = hexlify(self.p.read_config_memory(self.ATIS_CODE_OFFSET, 6)).decode().upper()
         atis = data[0:10]
         status = data[10:12]
         return atis, status
@@ -120,10 +137,10 @@ class GenericHXConfig(object):
         if status.upper() not in ["00", "01", "02", "FF"]:
             raise ProtocolError("Invalid ATIS status")
         data = unhexlify(atis + status)
-        self.p.write_config_memory(0x00b6, data)
+        self.p.write_config_memory(self.ATIS_CODE_OFFSET, data)
 
     def read_atis_enabled(self) -> int:
-        return ord(self.p.read_config_memory(0x00a2, 1))
+        return ord(self.p.read_config_memory(self.ATIS_ENABLED_OFFSET, 1))
 
     def write_atis_enabled(self, state: int):
         try:
@@ -132,10 +149,10 @@ class GenericHXConfig(object):
             raise ProtocolError("Invalid ATIS enabled format")
         if state not in [0, 1]:
             logger.warning("Unknown ATIS enabled value. Flashing anyway")
-        return self.p.write_config_memory(0x00a2, b)
+        return self.p.write_config_memory(self.ATIS_ENABLED_OFFSET, b)
 
     def read_region(self) -> int:
-        return ord(self.p.read_config_memory(0x010f, 1))
+        return ord(self.p.read_config_memory(self.REGION_CODE_OFFSET, 1))
 
     def write_region(self, region: int):
         try:
@@ -144,7 +161,7 @@ class GenericHXConfig(object):
             raise ProtocolError("Invalid region format")
         if region not in region_code_map:
             logger.warning("Unknown region. Flashing anyway")
-        return self.p.write_config_memory(0x010f, b)
+        return self.p.write_config_memory(self.REGION_CODE_OFFSET, b)
 
 
 class HX870Config(GenericHXConfig):
@@ -157,3 +174,5 @@ class HX890Config(GenericHXConfig):
     CONFIG_MAGIC = [0x03, 0x7a]
     CONFIG_SIZE = 0x10000
     FLASH_ID = ["AM063N"]
+    WAYPOINT_OFFSET = 0xd700
+    WAYPOINT_COUNT = 250

--- a/hxtool/config.py
+++ b/hxtool/config.py
@@ -2,6 +2,7 @@
 
 from binascii import hexlify, unhexlify
 from logging import getLogger
+from typing import Tuple
 
 from .memory import unpack_waypoint, region_code_map
 from .protocol import GenericHXProtocol, ProtocolError
@@ -139,8 +140,10 @@ class GenericHXConfig(object):
         data = unhexlify(atis + status)
         self.p.write_config_memory(self.ATIS_CODE_OFFSET, data)
 
-    def read_atis_enabled(self) -> int:
-        return ord(self.p.read_config_memory(self.ATIS_ENABLED_OFFSET, 1))
+    def read_atis_enabled(self) -> Tuple[bool, int]:
+        atis_config = ord(self.p.read_config_memory(self.ATIS_ENABLED_OFFSET, 1))
+        atis_enabled = atis_config & 1 == 1
+        return atis_enabled, atis_config
 
     def write_atis_enabled(self, state: int):
         try:
@@ -151,8 +154,10 @@ class GenericHXConfig(object):
             logger.warning("Unknown ATIS enabled value. Flashing anyway")
         return self.p.write_config_memory(self.ATIS_ENABLED_OFFSET, b)
 
-    def read_region(self) -> int:
-        return ord(self.p.read_config_memory(self.REGION_CODE_OFFSET, 1))
+    def read_region(self) -> Tuple[str, int]:
+        region_code = ord(self.p.read_config_memory(self.REGION_CODE_OFFSET, 1))
+        region = region_code_map[region_code]
+        return region, region_code
 
     def write_region(self, region: int):
         try:

--- a/hxtool/config.py
+++ b/hxtool/config.py
@@ -40,8 +40,8 @@ class GenericHXConfig(object):
         if magic != data[:2] or magic_end != data[-2:]:
             raise ProtocolError("Unexpected config magic in device")
         region = self.p.read_config_memory(0x010f, 1)
-        region_is_us = region == b'0xff'
-        data_is_us = data[0x010f] == b'0xff'
+        region_is_us = region == b'\xff'
+        data_is_us = data[0x010f] == 0xff
         if region_is_us != data_is_us:
             if check_region:
                 logger.error("Region mismatch")

--- a/hxtool/device.py
+++ b/hxtool/device.py
@@ -96,7 +96,6 @@ class HX870(object):
     usb_vendor_name = "YAESU MUSEN CO.,LTD."
     usb_product_id = 16
     usb_product_name = "HX870"
-    flash_id = ["AM057N", "AM057N2"]  # FIXME: Moved to config, remove here
 
     protocol_model = GenericHXProtocol
     config_model = HX870Config
@@ -145,7 +144,7 @@ class HX870(object):
         return self.comm.cp_mode
 
     def check_flash_id(self, flash_id: list = None):
-        return self.comm.check_flash_id(flash_id or self.flash_id)
+        return self.comm.check_flash_id(flash_id or self.config_model.FLASH_ID)
 
     def __str__(self):
         return f"{self.brand} {self.handle} on `{self.tty} [{'CP Mode' if self.comm.cp_mode else 'NMEA Mode'}]`"
@@ -162,7 +161,6 @@ class HX890(HX870):
     usb_vendor_name = "YAESU MUSEN CO.,LTD."
     usb_product_id = 30
     usb_product_name = "HX890"
-    flash_id = ["AM063N"]  # FIXME: Moved to config, remove here
 
     config_model = HX890Config
     nmea_model = HX890NMEAProtocol

--- a/hxtool/memory.py
+++ b/hxtool/memory.py
@@ -18,10 +18,13 @@ def unpack_waypoint(data):
     if wp_id == 255:
         return None
     wp_name = data[16:31].rstrip(b'\xff').decode("ascii")
+    wp_mmsi = hexlify(data[0:5]).decode()[0:9]
+    if wp_mmsi == "fffffffff":
+        wp_mmsi = None
 
-    lat_str = hexlify(data[4:9])[1:]
-    lat_deg = int(lat_str[0:3])
-    lat_min = int(lat_str[3:9]) / 10000.0
+    lat_str = hexlify(data[5:9])
+    lat_deg = int(lat_str[0:2])
+    lat_min = int(lat_str[2:8]) / 10000.0
     lat_dir = chr(data[9])
 
     lon_str = hexlify(data[10:15])
@@ -29,12 +32,13 @@ def unpack_waypoint(data):
     lon_min = int(lon_str[4:10]) / 10000.0
     lon_dir = chr(data[15])
 
-    wp_latitude = "%d%s%3.4f" % (lat_deg, lat_dir, lat_min)
-    wp_longitude = "%d%s%3.4f" % (lon_deg, lon_dir, lon_min)
+    wp_latitude = "%d%s%07.4f" % (lat_deg, lat_dir, lat_min)
+    wp_longitude = "%d%s%07.4f" % (lon_deg, lon_dir, lon_min)
 
     return {
         "id": wp_id,
         "name": wp_name,
+        "mmsi": wp_mmsi,
         "latitude": wp_latitude,
         "longitude": wp_longitude
     }

--- a/hxtool/simulator.py
+++ b/hxtool/simulator.py
@@ -49,7 +49,7 @@ class HXSimulator(Thread):
             # Populate config memory
             self.c = bytearray(b"\xff" * self.type.CONFIG_SIZE)
             fid = self.type.FLASH_ID[0].encode("ascii")
-            fid_offset = 0x0100
+            fid_offset = self.type.FLASH_ID_OFFSET
             self.c[fid_offset:fid_offset+len(fid)] = fid
 
         self.master, self.slave = openpty()

--- a/hxtool/simulator.py
+++ b/hxtool/simulator.py
@@ -42,7 +42,16 @@ class HXSimulator(Thread):
         self.type = device_type
         assert mode in ["CP", "NMEA"], "Invalid simulator mode"
         self.mode = mode
-        self.c = config or bytearray(b"\xff" * self.type.CONFIG_SIZE)
+        if config:
+            self.c = config
+            assert len(config) == self.type.CONFIG_SIZE, "Invalid config size"
+        else:
+            # Populate config memory
+            self.c = bytearray(b"\xff" * self.type.CONFIG_SIZE)
+            fid = self.type.FLASH_ID[0].encode("ascii")
+            fid_offset = 0x0100
+            self.c[fid_offset:fid_offset+len(fid)] = fid
+
         self.master, self.slave = openpty()
         self.tty = ttyname(self.slave)
         self.name = f"HXSimulator-{self.id} [{self.tty}]"
@@ -52,10 +61,6 @@ class HXSimulator(Thread):
         # FIXME: This will fail on Windows (probably on import)
         set_blocking(self.master, False)
         self.ignore_cmdok = False
-
-        # Populate config memory
-        fid = self.type.FLASH_ID[0].encode("ascii")
-        self.c[0x100:0x100+len(fid)] = fid
 
     def run(self):
         if self.stop_running.is_set():

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from binascii import unhexlify
 import pytest
 from sys import platform
 
@@ -11,8 +12,16 @@ if platform.startswith("win"):
 
 
 @pytest.fixture(name="cp_870_sim")
-def fixture_cp_simulator():
-    s = simulator.HXSimulator(config.HX870Config, mode="CP")
+def fixture_cp_870_simulator():
+    memory = bytearray(b"\xff" * 0x8000)
+    memory[0x00a2] = 0x00  # ATIS disabled
+    memory[0x00b0:0x00b6] = unhexlify("872345900003")  # MMSI
+    memory[0x00b6:0x00bc] = unhexlify("972345900005")  # ATIS
+    memory[0x010f] = 0x04  # region
+    memory[0x4300:0x4310] = unhexlify("9740019080544157174E001235956745")  # waypoint
+    memory[0x4310:0x4316] = "WPT001".encode("ascii")
+    memory[0x431f] = 0x01  # waypoint id
+    s = simulator.HXSimulator(config.HX870Config, mode="CP", config=memory)
     s.start()
     yield s
     s.stop()
@@ -20,8 +29,12 @@ def fixture_cp_simulator():
 
 
 @pytest.fixture(name="cp_890_sim")
-def fixture_cp_simulator():
-    s = simulator.HXSimulator(config.HX890Config, mode="CP")
+def fixture_cp_890_simulator():
+    memory = bytearray(b"\xff" * 0x10000)
+    memory[0xd700:0xd710] = unhexlify("FFFFFFFFF0404135384E007402668257")  # waypoint
+    memory[0xd710:0xd713] = "foo".encode("ascii")  # waypoint name
+    memory[0xd71f] = 0xf0  # waypoint id
+    s = simulator.HXSimulator(config.HX890Config, mode="CP", config=memory)
     s.start()
     yield s
     s.stop()
@@ -40,6 +53,11 @@ def fixture_config_simulator(cp_870_sim):
     yield config.HX870Config(protocol.GenericHXProtocol(cp_870_sim.tty))
 
 
+@pytest.fixture(name="sim_890_config")
+def fixture_config_890_simulator(cp_890_sim):
+    yield config.HX890Config(protocol.GenericHXProtocol(cp_890_sim.tty))
+
+
 # @pytest.mark.skip
 # def test_cp_870_config_rw(cp_870_sim, kill_sims):
 #     del kill_sims
@@ -51,3 +69,117 @@ def fixture_config_simulator(cp_870_sim):
 #     p.write_config_memory(0x1000, random_bytes)
 #     m = p.read_config_memory(0x1000, len(random_bytes))
 #     assert m == random_bytes
+
+
+def test_hx870_mmsi(sim_870_config):
+    mmsi, status = sim_870_config.read_mmsi()
+    assert mmsi == "872345900", "MMSI offset"
+    assert status == "03", "MMSI save counter"
+
+    sim_870_config.write_mmsi(mmsi="318765432", status="02")
+    mmsi, status = sim_870_config.read_mmsi()
+    assert mmsi == "318765432", "MMSI write/read"
+    assert status == "02", "MMSI save counter write/read"
+
+    sim_870_config.write_mmsi()
+    mmsi, status = sim_870_config.read_mmsi()
+    assert mmsi == "FFFFFFFFF", "MMSI reset"
+    assert status == "00", "MMSI reset save counter"
+
+    sim_870_config.write_mmsi(mmsi="1112223330")
+    mmsi, status = sim_870_config.read_mmsi()
+    assert mmsi == "111222333", "10th digit is accepted but dropped"
+    assert status not in ["00", "FF"], "save counter is set automatically"
+
+    with pytest.raises(protocol.ProtocolError):
+        sim_870_config.write_mmsi(mmsi="12345678")  # too short
+    with pytest.raises(protocol.ProtocolError):
+        sim_870_config.write_mmsi(mmsi="11111f111")  # not numeric
+    with pytest.raises(protocol.ProtocolError):
+        sim_870_config.write_mmsi(mmsi="123456789", status="gh")  # invalid save counter
+
+
+def test_hx870_atis(sim_870_config):
+    atis, status = sim_870_config.read_atis()
+    assert atis == "9723459000", "ATIS offset"
+    assert status == "05", "ATIS save counter"
+
+    sim_870_config.write_atis(atis="9318765432", status="02")
+    atis, status = sim_870_config.read_atis()
+    assert atis == "9318765432", "ATIS write/read"
+    assert status == "02", "ATIS save counter write/read"
+
+    sim_870_config.write_atis()
+    atis, status = sim_870_config.read_atis()
+    assert atis == "FFFFFFFFFF", "ATIS reset"
+    assert status == "00", "ATIS reset save counter"
+
+    sim_870_config.write_atis(atis="9876543210")
+    atis, status = sim_870_config.read_atis()
+    assert status not in ["00", "FF"], "save counter is set automatically"
+
+    with pytest.raises(protocol.ProtocolError):
+        sim_870_config.write_atis(atis="987654321")  # too short
+    with pytest.raises(protocol.ProtocolError):
+        sim_870_config.write_atis(atis="91111f1111")  # not numeric
+    with pytest.raises(protocol.ProtocolError):
+        sim_870_config.write_atis(atis="2987654321")  # doesn't start with 9
+    with pytest.raises(protocol.ProtocolError):
+        sim_870_config.write_atis(atis="9876543210", status="gh")  # invalid save counter
+
+    atis_config = sim_870_config.read_atis_enabled()
+    assert atis_config == 0, "ATIS disabled"
+
+    sim_870_config.write_atis_enabled(True)
+    assert sim_870_config.read_atis_enabled() == 1, "ATIS enabled write/read"
+
+    with pytest.raises(protocol.ProtocolError):
+        sim_870_config.write_atis_enabled(999)
+
+
+def test_hx870_region(sim_870_config):
+    code = sim_870_config.read_region()
+    assert code == 4, "region code"
+
+    sim_870_config.write_region(0xff)
+    assert sim_870_config.read_region() == 0xff, "region code write/read"
+
+    with pytest.raises(protocol.ProtocolError):
+        sim_870_config.write_region(0x100)  # too large
+
+
+def test_hx870_waypoints(sim_870_config):
+    waypoints = sim_870_config.read_waypoints()
+
+    assert waypoints[0]["id"] == 1, "wpt 1 id"
+    assert waypoints[0]["name"] == "WPT001", "wpt 1 name"
+    assert waypoints[0]["latitude"] == "54N41.5717", "wpt 1 lat"
+    assert waypoints[0]["longitude"] == "12E35.9567", "wpt 1 lon"
+
+
+@pytest.mark.xfail
+def test_hx890_waypoints(sim_890_config):
+    waypoints = sim_890_config.read_waypoints()
+
+    assert len(waypoints) == 1
+    assert waypoints[0]["id"] == 240, "wpt 1 id"
+    assert waypoints[0]["name"] == "foo", "wpt 1 name"
+    assert waypoints[0]["mmsi"] is None, "wpt 1 mmsi"
+    assert waypoints[0]["latitude"] == "40N41.3538", "wpt 1 lat"
+    assert waypoints[0]["longitude"] == "74W02.6682", "wpt 1 lon"
+
+
+@pytest.mark.slow
+def test_hx870_config(sim_870_config):
+    data = bytearray(sim_870_config.config_read())
+    data[0x00b0:0x00b5] = unhexlify("9793485160")  # MMSI
+    data[0x010f] = 0xff  # region mismatch (will be ignored)
+    sim_870_config.config_write(data, check_region=False)
+    assert sim_870_config.read_mmsi()[0] == "979348516"
+    assert sim_870_config.read_region() == 0xff
+
+    with pytest.raises(protocol.ProtocolError):
+        sim_870_config.config_write(b"\xff" * 0x8001)  # wrong data size
+    with pytest.raises(protocol.ProtocolError):
+        data[0x0000] = 0x56  # wrong magic
+        sim_870_config.config_write(data)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -141,8 +141,17 @@ def test_hx870_region(sim_870_config):
     code = sim_870_config.read_region()
     assert code == 4, "region code"
 
+    with pytest.raises(protocol.ProtocolError):
+        data = bytearray(b"\xff" * 0x8000)
+        sim_870_config.config_write(data)  # region mismatch
+
     sim_870_config.write_region(0xff)
     assert sim_870_config.read_region() == 0xff, "region code write/read"
+
+    with pytest.raises(protocol.ProtocolError):
+        data = bytearray(b"\xff" * 0x8000)
+        data[0x010f] = 0x01
+        sim_870_config.config_write(data)  # region mismatch
 
     with pytest.raises(protocol.ProtocolError):
         sim_870_config.write_region(0x100)  # too large

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -176,7 +176,6 @@ def test_hx870_waypoints(sim_870_config):
     assert waypoints[1]["longitude"] == "109W17.1667", "wpt 2 lon"
 
 
-@pytest.mark.xfail
 def test_hx890_waypoints(sim_890_config):
     waypoints = sim_890_config.read_waypoints()
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -21,6 +21,9 @@ def fixture_cp_870_simulator():
     memory[0x4300:0x4310] = unhexlify("9740019080544157174E001235956745")  # waypoint
     memory[0x4310:0x4316] = "WPT001".encode("ascii")
     memory[0x431f] = 0x01  # waypoint id
+    memory[0x4320:0x4330] = unhexlify("FFFFFFFFFF2707433353010917166757")  # waypoint
+    memory[0x4330:0x433f] = "long waypoint 2".encode("ascii")
+    memory[0x433f] = 0x02  # waypoint id
     s = simulator.HXSimulator(config.HX870Config, mode="CP", config=memory)
     s.start()
     yield s
@@ -162,8 +165,15 @@ def test_hx870_waypoints(sim_870_config):
 
     assert waypoints[0]["id"] == 1, "wpt 1 id"
     assert waypoints[0]["name"] == "WPT001", "wpt 1 name"
+    assert waypoints[0]["mmsi"] == "974001908", "wpt 1 mmsi"
     assert waypoints[0]["latitude"] == "54N41.5717", "wpt 1 lat"
     assert waypoints[0]["longitude"] == "12E35.9567", "wpt 1 lon"
+
+    assert waypoints[1]["id"] == 2, "wpt 2 id"
+    assert waypoints[1]["name"] == "long waypoint 2", "wpt 2 name"
+    assert waypoints[1]["mmsi"] is None, "wpt 2 mmsi"
+    assert waypoints[1]["latitude"] == "27S07.4333", "wpt 2 lat"
+    assert waypoints[1]["longitude"] == "109W17.1667", "wpt 2 lon"
 
 
 @pytest.mark.xfail

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -130,18 +130,20 @@ def test_hx870_atis(sim_870_config):
     with pytest.raises(protocol.ProtocolError):
         sim_870_config.write_atis(atis="9876543210", status="gh")  # invalid save counter
 
-    atis_config = sim_870_config.read_atis_enabled()
-    assert atis_config == 0, "ATIS disabled"
+    atis_enabled, atis_config = sim_870_config.read_atis_enabled()
+    assert not atis_enabled, "ATIS enabled offset"
+    assert atis_config == 0, "ATIS enabled"
 
     sim_870_config.write_atis_enabled(True)
-    assert sim_870_config.read_atis_enabled() == 1, "ATIS enabled write/read"
+    assert sim_870_config.read_atis_enabled()[0], "ATIS enabled write/read"
 
     with pytest.raises(protocol.ProtocolError):
         sim_870_config.write_atis_enabled(999)
 
 
 def test_hx870_region(sim_870_config):
-    code = sim_870_config.read_region()
+    region, code = sim_870_config.read_region()
+    assert region == "SWEDEN", "region code offset"
     assert code == 4, "region code"
 
     with pytest.raises(protocol.ProtocolError):
@@ -149,7 +151,7 @@ def test_hx870_region(sim_870_config):
         sim_870_config.config_write(data)  # region mismatch
 
     sim_870_config.write_region(0xff)
-    assert sim_870_config.read_region() == 0xff, "region code write/read"
+    assert sim_870_config.read_region()[1] == 0xff, "region code write/read"
 
     with pytest.raises(protocol.ProtocolError):
         data = bytearray(b"\xff" * 0x8000)
@@ -194,7 +196,7 @@ def test_hx870_config(sim_870_config):
     data[0x010f] = 0xff  # region mismatch (will be ignored)
     sim_870_config.config_write(data, check_region=False)
     assert sim_870_config.read_mmsi()[0] == "979348516"
-    assert sim_870_config.read_region() == 0xff
+    assert sim_870_config.read_region()[1] == 0xff
 
     with pytest.raises(protocol.ProtocolError):
         sim_870_config.config_write(b"\xff" * 0x8001)  # wrong data size


### PR DESCRIPTION
These changes make adding support for other devices easier by parameterizing config memory locations. Sets up #40.

Adding tests for the `config` module exposed a few issues, which this PR tries to address.

The GX1400 doesn’t store the selected region and the ATIS enabled flag in quite the same format as the HX870/HX890. https://github.com/cr/hx870/commit/03a36854efbc924366f114ae9c0af30139b29186 moves the code parsing that data from the `info` CLI command into the `config` module. `read_region()` and `read_atis_enabled()` are modified to return a tuple instead of a scalar. These methods exist in the `dev` branch, but haven’t been merged into `master` yet, so this shouldn’t be a breaking change for users.