### PR TITLE
Add capability to connect to GX1400 radio

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ are the **HX870**, **HX890**, and **GX1400** model series.
 Radios with a USB port (like HX870 and HX890) are automatically detected when
 connected. By contrast, the GX1400 is connected to a RS-232 style serial port,
 which must be manually selected with the `--tty` and `--model` CLI options.
-The GX1400 connector wiring is as follows. See the [ShSync](https://mbof.github.io/hx/) docs for a
+The GX1400 connector wiring is as follows. See the [SHsync](https://mbof.github.io/hx/) docs for a
 [diagram of the DE-9 connector pin-out](https://github.com/mbof/hxsync/blob/main/gx.md#wiring-diagram).
 
 * `RxD`: accessory cable white

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ are the **HX870**, **HX890**, and **GX1400** model series.
 Radios with a USB port (like HX870 and HX890) are automatically detected when
 connected. By contrast, the GX1400 is connected to a RS-232 style serial port,
 which must be manually selected with the `--tty` and `--model` CLI options.
-The GX1400 connector wiring is as follows:
+The GX1400 connector wiring is as follows. See the [ShSync](https://mbof.github.io/hx/) docs for a
+[diagram of the DE-9 connector pin-out](https://github.com/mbof/hxsync/blob/main/gx.md#wiring-diagram).
 
 * `RxD`: accessory cable white
 * `TxD`: accessory cable yellow

--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 Here's my collection of experimental Python code and reverse engineering notes
 for hacking the Standard Horizon HX-style maritime radios by Yaesu. Currently supported
-are the *HX870* and *HX890* model series. The code also works on FT750-style aviation
+are the **HX870**, **HX890**, and **GX1400** model series.
+
+Radios with a USB port (like HX870 and HX890) are automatically detected when
+connected. By contrast, the GX1400 is connected to a RS-232 style serial port,
+which must be manually selected with the `--tty` and `--model` CLI options.
+The GX1400 connector wiring is as follows:
+
+* `RxD`: accessory cable white
+* `TxD`: accessory cable yellow
+* `GND`: accessory cable green + speaker cable shield
+
+The code also works on FT750-style aviation
 radios, which share the same hardware platform, to some degree as well, but that
 functionality is not exposed on the command line frontend, yet.
 

--- a/hxtool/config.py
+++ b/hxtool/config.py
@@ -189,3 +189,59 @@ class HX891Config(GenericHXConfig):
     FLASH_ID = ["AM070N"]
     WAYPOINT_OFFSET = 0xd700
     WAYPOINT_COUNT = 250
+
+
+class GX1400Config(GenericHXConfig):
+
+    CONFIG_MAGIC = [0x05, 0x78]
+    FLASH_ID = ["AM065N"]
+
+    CHUNK_SIZE = 0x20
+    CONFIG_SIZE = 0x2000
+    PROGRESS_LOG_AT = 0x0800
+
+    MMSI_OFFSET = 0x0060
+    ATIS_CODE_OFFSET = 0x0066
+    ATIS_ENABLED_OFFSET = 0x0052
+    FLASH_ID_OFFSET = 0x0098
+    REGION_CODE_OFFSET = 0x009f
+    WAYPOINT_OFFSET = None
+
+    REGION_CODE_US = 0x00
+    WAYPOINT_COUNT = 0
+
+    def config_write(self, data, check_region=True, progress=False):
+        self._config_write_precheck(data, check_region)
+        bytes_to_go = self.CONFIG_SIZE
+        if progress:
+            logger.info(f"0 / {bytes_to_go} bytes (0%)")
+        # Skip writing the following data to the device:
+        # magic, firmware version, flash ID, unknown 0x00a0-0x00bf, last
+        # turned off fix, serial no, production date, some padding at the end
+        self.p.write_config_memory(0x0002, data[0x0002:0x001d])
+        self.p.write_config_memory(0x0020, data[0x0020:0x0040])
+        self.p.write_config_memory(0x0040, data[0x0040:0x0060])
+        self.p.write_config_memory(0x0060, data[0x0060:0x0080])
+        self.p.write_config_memory(0x0080, data[0x0080:0x0098])
+        self.p.write_config_memory(0x009f, data[0x009f:0x00a0])
+        self.p.write_config_memory(0x00d0, data[0x00d0:0x00f0])
+        self.p.write_config_memory(0x00f0, data[0x00f0:0x0110])
+        for offset in range(0x0120, 0x1fa0, self.CHUNK_SIZE):
+            if progress:
+                percent_done = int(100.0 * offset / bytes_to_go)
+                if offset % self.PROGRESS_LOG_AT == 0:
+                    logger.info(f"{offset} / {bytes_to_go} bytes ({percent_done}%)")
+            self.p.write_config_memory(offset, data[offset:offset+self.CHUNK_SIZE])
+        if progress:
+            logger.info(f"{bytes_to_go} / {bytes_to_go} bytes (100%)")
+
+    def read_waypoints(self):
+        raise ProtocolError("Waypoints unsupported by GX1400")
+
+    def read_region(self):
+        region_code = ord(self.p.read_config_memory(self.REGION_CODE_OFFSET, 1))
+        try:
+            region = ["USA", "INTL", "UK", "BE", "NL", "SW", "GRM", "JPN"][region_code]
+        except IndexError:
+            region = ""
+        return region, region_code

--- a/hxtool/device.py
+++ b/hxtool/device.py
@@ -3,9 +3,9 @@
 from logging import getLogger
 from serial.tools import list_ports
 
-from .config import HX870Config, HX890Config, HX891Config
+from .config import HX870Config, HX890Config, HX891Config, GX1400Config
 from .nmea import HX870NMEAProtocol, HX890NMEAProtocol
-from .protocol import GenericHXProtocol, MediaTekProtocol
+from .protocol import GenericHXProtocol, GX1400Protocol, MediaTekProtocol
 from .simulator import HXSimulator
 
 logger = getLogger(__name__)
@@ -39,6 +39,10 @@ def enumerate(force_device=None, force_model=None, add_simulator=False):
         sim.start()
         devices.append(HX891Sim(sim.tty))
 
+        sim = HXSimulator(GX1400Config, mode="CP")
+        sim.start()
+        devices.append(GX1400(sim.tty))
+
     if force_device is None and force_model is None:
         for model in models.values():
             devices += enumerate_model(model)
@@ -57,10 +61,15 @@ def enumerate(force_device=None, force_model=None, add_simulator=False):
                 return []
 
         # Device is given as tty spec, so autodetect model
-        for m in [HX870, HX890]:
-            d = m(force_device)
-            if d.check_flash_id():
-                return [d]
+        for m in [HX891, HX890, HX870, GX1400]:
+            # Waiting for the timeout for each device is a bit crude, but it
+            # gets the job done.
+            try:
+                d = m(force_device)
+                if d.check_flash_id():
+                    return [d]
+            except TimeoutError:
+                logger.warning(f"Timeout when treating {force_device} as {m.handle}")
         else:
             logger.warning(f"Unable to detect model listening on {force_device}. Try specifying --model.")
             return []
@@ -82,6 +91,9 @@ def enumerate(force_device=None, force_model=None, add_simulator=False):
 def enumerate_model(hx_device) -> list:
 
     devices = []
+
+    if hx_device.usb_vendor_id is None and hx_device.usb_product_id is None:
+        return devices
 
     for d in list_ports.comports():
         if d.vid == hx_device.usb_vendor_id and d.pid == hx_device.usb_product_id:
@@ -190,6 +202,53 @@ class HX891(HX890):
     nmea_model = HX890NMEAProtocol
 
 
+class GX1400(HX870):
+    """
+    Device object for Standard Horizon GX1400 maritime radios
+    """
+    handle = "GX1400"
+    brand = "Standard Horizon"
+    model = "GX1400"
+    usb_vendor_id = None
+    usb_vendor_name = None
+    usb_product_id = None
+    usb_product_name = None
+    flash_id = ["AM065N"]
+
+    protocol_model = GX1400Protocol
+    config_model = GX1400Config
+    nmea_model = None
+
+    def __init__(self, tty):
+        # Overriding __init_config() in this class is only possible by
+        # using the name _HX870__init_config(), which would be confusing.
+        # Therefore, the constructor definition must be repeated here,
+        # even though it's identical to the one in the superclass.
+        self.tty = tty
+        self.comm = self.protocol_model(tty=tty)
+        self.config = None
+        self.nmea = None
+        self.__init_config()
+
+    def __init_config(self):
+        # Verify we're talking to a GX1400 on that tty
+        self.comm.hx_hardware = self.check_flash_id()
+        if self.comm.hx_hardware and self.comm.cp_mode:
+            self.config = self.config_model(self.comm)
+
+            # There are multiple GX1400 variants. The variant type can be
+            # read from the device's memory, so let's just use that string
+            # to refer to the device here.
+            variant = self.comm.read_config_memory(0xd0, 14).rstrip(b"\xff").decode()
+            if variant:
+                self.handle = variant
+
+            fw = self.comm.get_firmware_version()
+            logger.info(f"Device on {self.tty} is {self.handle}, firmware version {fw}")
+        else:
+            logger.error(f"Device on {self.tty} does not behave or look like GX1400")
+
+
 class HX870Sim(HX870):
     """
     Device object for Standard Horizon HX870 maritime radio simulator
@@ -221,6 +280,6 @@ class HX891Sim(HX891):
 
 
 models = {}
-for model_class in HX870, HX890, HX891:
+for model_class in HX870, HX890, HX891, GX1400:
     models[model_class.handle.upper()] = model_class
 del model_class

--- a/hxtool/device.py
+++ b/hxtool/device.py
@@ -61,15 +61,10 @@ def enumerate(force_device=None, force_model=None, add_simulator=False):
                 return []
 
         # Device is given as tty spec, so autodetect model
-        for m in [HX891, HX890, HX870, GX1400]:
-            # Waiting for the timeout for each device is a bit crude, but it
-            # gets the job done.
-            try:
-                d = m(force_device)
-                if d.check_flash_id():
-                    return [d]
-            except TimeoutError:
-                logger.warning(f"Timeout when treating {force_device} as {m.handle}")
+        for m in [HX870, HX890]:
+            d = m(force_device)
+            if d.check_flash_id():
+                return [d]
         else:
             logger.warning(f"Unable to detect model listening on {force_device}. Try specifying --model.")
             return []

--- a/hxtool/device.py
+++ b/hxtool/device.py
@@ -128,9 +128,9 @@ class HX870(object):
         self.config = None
         self.nmea = None
         self.gps = None
-        self.__init_config()
+        self.init_config()
 
-    def __init_config(self):
+    def init_config(self):
         # See what we're talking to on that tty
         if self.comm.hx_hardware:
             if self.comm.cp_mode:
@@ -219,18 +219,7 @@ class GX1400(HX870):
     config_model = GX1400Config
     nmea_model = None
 
-    def __init__(self, tty):
-        # Overriding __init_config() in this class is only possible by
-        # using the name _HX870__init_config(), which would be confusing.
-        # Therefore, the constructor definition must be repeated here,
-        # even though it's identical to the one in the superclass.
-        self.tty = tty
-        self.comm = self.protocol_model(tty=tty)
-        self.config = None
-        self.nmea = None
-        self.__init_config()
-
-    def __init_config(self):
+    def init_config(self):
         # Verify we're talking to a GX1400 on that tty
         self.comm.hx_hardware = self.check_flash_id()
         if self.comm.hx_hardware and self.comm.cp_mode:

--- a/hxtool/main.py
+++ b/hxtool/main.py
@@ -40,7 +40,7 @@ def get_args(args=None):
     parser.add_argument("-m", "--model",
                         help="force device model",
                         type=str.upper,
-                        choices=["HX870", "HX890"],
+                        choices=["HX870", "HX890", "GX1400"],
                         action="store")
 
     parser.add_argument("--simulator",

--- a/hxtool/protocol.py
+++ b/hxtool/protocol.py
@@ -512,3 +512,50 @@ class MediaTekProtocol(object):
         r = self.receive()
         if r.type != "$PMTK" or len(r.args) != 3 or r.args != ["001", "184", "3"]:
             raise ProtocolError(f"Unexpected EraseLog acknowledgement from device: {str(r).strip()}")
+
+
+class GX1400Protocol(GenericHXProtocol):
+
+    def __init__(self, tty=None):
+        self.conn = None
+        self.connected = False
+        self.hx_hardware = False
+        self.cp_mode = False
+        self.nmea_mode = False
+        self.__connect(tty)
+
+    def __connect(self, tty):
+        self.conn = hxtty.GenericHXTTY(tty, baudrate=38400)
+        self.connected = True
+        logger.debug("Attempting GX1400 sync")
+        try:
+            self.sync()
+        except TimeoutError:
+            logger.warning("No response, so probably not talking to GX1400")
+            self.hx_hardware = False
+            self.cp_mode = False
+            return
+
+        logger.debug("Sync successful, assuming GX1400 hardware and CP mode")
+        self.hx_hardware = True
+        self.cp_mode = True
+
+        # On the GX1400, there doesn't appear to be a distinction between
+        # CP mode and command mode. The device is immediately ready for use.
+        # However, since it's a generic serial link, there is no way to know
+        # in advance whether or not the connected device is in fact a GX1400.
+
+        # NMEA mode is currently not detected. The device can be configured to
+        # send NMEA data at 38400 baud, so adding this feature here may not be
+        # too difficult. But given that NMEA data comes in from the GX1400 over
+        # a regular serial link rather than USB, dedicated NMEA software is
+        # probably more suited than hxtool for reading it anyway.
+
+    def get_firmware_version(self):
+        self.sync()
+        data = hexlify(self.read_config_memory(0x1d, 3)).decode()
+        return (data[1] if data.startswith("0") else data[0:2]) + "." + data[2:4]
+
+    def get_flash_id(self):
+        self.sync()
+        return self.read_config_memory(0x98, 7).rstrip(b"\x00\xff").decode("ascii")

--- a/hxtool/tty.py
+++ b/hxtool/tty.py
@@ -11,7 +11,7 @@ class GenericHXTTY(object):
     Serial communication for Standard Horizon HX maritime radios
     """
 
-    def __init__(self, tty, timeout=2):
+    def __init__(self, tty, timeout=2, baudrate=9600):
         """
         Serial connection class for HX870 handsets
 
@@ -21,7 +21,7 @@ class GenericHXTTY(object):
         self.tty = tty
         logger.debug(f"Connecting to {tty}")
         self.default_timeout = timeout
-        self.s = Serial(tty, timeout=timeout)
+        self.s = Serial(tty, baudrate, timeout=timeout)
         self.s.flushInput()
         self.s.flushOutput()
 

--- a/tests/gx1400_test.py
+++ b/tests/gx1400_test.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+
+from binascii import unhexlify
+import os
+import pytest
+from sys import platform
+
+from hxtool.config import GX1400Config
+from hxtool.device import GX1400
+from hxtool.main import main
+from hxtool.protocol import ProtocolError
+from hxtool.simulator import HXSimulator
+
+# The simulator may not work on Windows, so skip test if running on Windows
+if platform.startswith("win"):
+    pytest.skip("Skipping simulator tests on Windows", allow_module_level=True)
+
+
+@pytest.fixture(name="blank_sim")
+def fixture_blank_simulator():
+    blank = bytearray(b"\xff" * 0x2000)
+    s = HXSimulator(GX1400Config, mode="CP", config=blank)
+    s.start()
+    yield s
+    s.stop()
+    s.join(timeout=1)
+
+
+@pytest.fixture(name="gx1400_sim")
+def fixture_gx1400_simulator():
+    memory = bytearray(b"\xff" * 0x2000)
+    memory[0x001d:0x001f] = unhexlify("0099")  # firmware version
+    memory[0x0052] = 0x20  # ATIS disabled
+    memory[0x0060:0x0066] = unhexlify("972001400001")  # MMSI
+    memory[0x0066:0x006c] = unhexlify("997200140006")  # ATIS
+    memory[0x0096:0x0098] = unhexlify("0005")  # code clear counters
+    memory[0x0098:0x009e] = "AM065N".encode("ascii")  # flash ID
+    memory[0x009f] = 0x01  # region
+    memory[0x00d0:0x00dd] = "GX1400GPS-SIM".encode("ascii")  # model variant
+    s = HXSimulator(GX1400Config, mode="CP", config=memory)
+    s.start()
+    yield s
+    s.stop()
+    s.join(timeout=1)
+
+
+def test_blank_device(capsys, blank_sim):
+    device = GX1400(blank_sim.tty)
+    outerr = capsys.readouterr()
+    assert "does not behave or look like GX1400" in outerr.err
+
+
+def test_gx1400_device(gx1400_sim):
+    device = GX1400(gx1400_sim.tty)
+
+    assert device.comm.hx_hardware
+    assert device.comm.cp_mode
+    assert device.comm.get_firmware_version() == "0.99"
+    assert device.handle == "GX1400GPS-SIM"
+
+
+def test_gx1400_config_offsets(gx1400_sim):
+    config = GX1400(gx1400_sim.tty).config
+
+    mmsi, mmsi_status = config.read_mmsi()
+    atis, atis_status = config.read_atis()
+    assert mmsi == "972001400", "MMSI"
+    assert mmsi_status == "01", "MMSI save counter"
+    assert atis == "9972001400", "ATIS"
+    assert atis_status == "06", "ATIS save counter"
+
+    atis_enabled, atis_config = config.read_atis_enabled()
+    assert not atis_enabled, "ATIS enabled"
+    assert atis_config == 0x20, "ATIS enabled code"
+
+    region, region_code = config.read_region()
+    assert region == "INTL", "region short name"
+    assert region_code == 0x01, "region code"
+
+    with pytest.raises(ProtocolError):
+        config.read_waypoints()
+
+
+def test_gx1400_region(gx1400_sim):
+    config = GX1400(gx1400_sim.tty).config
+
+    config.write_region(73)
+    region, code = config.read_region()
+    assert region == "", "unknown region"
+    assert code == 73, "region code"
+
+    with pytest.raises(ProtocolError):
+        data = bytearray(b"\xff" * 0x2000)
+        data[0x009f] = 0x00
+        config.config_write(data)  # region mismatch
+
+
+def test_gx1400_config_write(gx1400_sim, capsys):
+    config = GX1400(gx1400_sim.tty).config
+
+    data = bytearray(config.config_read())
+    data[0x0060:0x0065] = unhexlify("9987064120")  # MMSI
+    config.config_write(data, progress=True)
+
+    assert config.read_mmsi()[0] == "998706412"
+
+    outerr = capsys.readouterr()
+    assert "0 / 8192 bytes (0%)" in outerr.err
+    assert "2048 / 8192 bytes (25%)" in outerr.err
+    assert "8192 / 8192 bytes (100%)" in outerr.err
+
+
+@pytest.mark.xfail
+def test_gx1400_save_counters(gx1400_sim):
+    config = GX1400(gx1400_sim.tty).config
+
+    # The "status" byte counts the number of times the code has been saved
+    config.write_mmsi(mmsi="876543210", status=6)
+    assert config.read_mmsi()[1] == 6
+    config.write_atis(atis="9876543210", status=7)
+    assert config.read_atis()[1] == 7
+
+    # Changing the code increments the save counter
+    config.write_mmsi(mmsi="888777666")
+    config.write_atis(atis="9998887770")
+    assert config.read_mmsi()[1] == 7
+    assert config.read_atis()[1] == 8
+
+    mmsi_clear_counter = ord(config.p.read_config_memory(0x0096, 1))
+    atis_clear_counter = ord(config.p.read_config_memory(0x0097, 1))
+
+    # Clearing the code doesn't change the save counter
+    config.write_mmsi(mmsi=None)
+    config.write_atis(atis=None)
+    assert config.read_mmsi()[1] == 7
+    assert config.read_atis()[1] == 8
+
+    # ... but increments the clear counter
+    assert ord(config.p.read_config_memory(0x0096, 1)) == mmsi_clear_counter + 1
+    assert ord(config.p.read_config_memory(0x0097, 1)) == atis_clear_counter + 1
+
+
+def test_hxtool_devices(capsys):
+    args = [
+        "--simulator",
+        "devices",
+    ]
+    ret = main(args)
+    assert ret == 0, "hxtool --simulator devices returns 0"
+
+    outerr = capsys.readouterr()
+    out = outerr.out.strip("\n").split("\n")
+    gx1400 = [device for device in out if "GX1400" in device]
+    assert len(gx1400) == 1, "One GX1400 simulator detected"
+
+    device = gx1400[0].split("\t")
+    assert GX1400.brand in device
+    assert GX1400.model in device
+    assert "CP mode" in device


### PR DESCRIPTION
See #40 for context.

I was hoping to have time this weekend to find a better solution for the model auto-detection in [`device.enumerate()`](https://github.com/johannessen/pyhx870/blob/285be9ce5c94e4364fdb922b693144fdbfc07060/hxtool/device.py#L54-L66), but didn’t get around to it after all.

I’ll be leaving a few inline review comments / questions.
