### PR TITLE
Rewrite device model auto-detection to use config memory magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Here's my collection of experimental Python code and reverse engineering notes
 for hacking the Standard Horizon HX-style maritime radios by Yaesu. Currently supported
 are the **HX870**, **HX890**, and **GX1400** model series.
 
-Radios with a USB port (like HX870 and HX890) are automatically detected when
-connected. By contrast, the GX1400 is connected to a RS-232 style serial port,
-which must be manually selected with the `--tty` and `--model` CLI options.
+Radios in "CP mode" are usually automatically detected when connected.
+You can also manually select devices with the `--tty` or `--model` CLI options.
+
+The GX1400 has no USB port and is connected to a RS-232 style serial port.
 The GX1400 connector wiring is as follows. See the [SHsync](https://mbof.github.io/hx/) docs for a
 [diagram of the DE-9 connector pin-out](https://github.com/mbof/hxsync/blob/main/gx.md#wiring-diagram).
 

--- a/hxtool/__init__.py
+++ b/hxtool/__init__.py
@@ -32,7 +32,7 @@ def get(args):
     devices = device.enumerate(force_model=args.model, force_device=args.tty, add_simulator=args.simulator)
 
     if len(devices) == 0:
-        logger.critical("No device detected. Connect device or try specifying --tty")
+        logger.critical("No device detected. Connect device or try specifying --tty and --model")
         return None
 
     if len(devices) > 1:

--- a/hxtool/config.py
+++ b/hxtool/config.py
@@ -12,7 +12,7 @@ logger = getLogger(__name__)
 
 class GenericHXConfig(object):
 
-    CONFIG_MAGIC = [0xff, 0xff]
+    CONFIG_MAGIC = 0xffff
     FLASH_ID = ["AM000A"]
 
     CHUNK_SIZE = 0x40
@@ -170,13 +170,13 @@ class GenericHXConfig(object):
 
 
 class HX870Config(GenericHXConfig):
-    CONFIG_MAGIC = [0x03, 0x67]
+    CONFIG_MAGIC = 871
     CONFIG_SIZE = 0x8000
     FLASH_ID = ["AM057N", "AM057N2"]
 
 
 class HX890Config(GenericHXConfig):
-    CONFIG_MAGIC = [0x03, 0x7a]
+    CONFIG_MAGIC = 890
     CONFIG_SIZE = 0x10000
     FLASH_ID = ["AM063N"]
     WAYPOINT_OFFSET = 0xd700
@@ -184,7 +184,7 @@ class HX890Config(GenericHXConfig):
 
 
 class HX891Config(GenericHXConfig):
-    CONFIG_MAGIC = [0x03, 0x7b]
+    CONFIG_MAGIC = 891
     CONFIG_SIZE = 0x10000
     FLASH_ID = ["AM070N"]
     WAYPOINT_OFFSET = 0xd700
@@ -193,7 +193,7 @@ class HX891Config(GenericHXConfig):
 
 class GX1400Config(GenericHXConfig):
 
-    CONFIG_MAGIC = [0x05, 0x78]
+    CONFIG_MAGIC = 1400
     FLASH_ID = ["AM065N"]
 
     CHUNK_SIZE = 0x20

--- a/hxtool/device.py
+++ b/hxtool/device.py
@@ -1,85 +1,139 @@
 # -*- coding: utf-8 -*-
 
 from logging import getLogger
+import os
+import re
 from serial.tools import list_ports
 import sys
-from typing import Iterable, Tuple, Type
+from typing import Iterable, List, Optional, Set, Tuple, Type
 
 from .config import HX870Config, HX890Config, HX891Config, GX1400Config
 from .nmea import HX870NMEAProtocol, HX890NMEAProtocol
-from .protocol import GenericHXProtocol, GX1400Protocol, MediaTekProtocol
+from .protocol import GenericHXProtocol, GX1400Protocol, MediaTekProtocol, ReadMagicProtocol
 from .simulator import HXSimulator
 
 logger = getLogger(__name__)
 
 
+# Probing all available ports for the config magic may cause errors and timeout delays,
+# so exclude ports with known issues and offer users a way to specify the port list.
+include_ports = os.environ.get("HXTOOL_SERIAL_PORTS", "").split()
+exclude_ports = [
+    # macOS
+    "/dev/cu.BLTH",
+    "/dev/cu.Bluetooth-Incoming-Port",
+    "/dev/cu.URT1",
+    "/dev/cu.URT2",
+]
+
+
 def enumerate(force_device=None, force_model=None, add_simulator=False):
 
     global models
-    model_list = models.values()
+    if force_model:
+        try:
+            model_list = [models[force_model.upper()]]
+        except KeyError:
+            logger.critical(f"Invalid model specifier `{force_model}`")
+            return []
+    else:
+        model_list = models.values()
 
     devices = []
 
     if add_simulator:
         for model in model_list:
             devices += model.simulators()
-        devices = [model(tty) for model, tty in devices]
 
-    if force_device is None and force_model is None:
-        for model in models.values():
-            devices += enumerate_model(model)
-        return devices
+    devices += enumerate_devices(model_list, force_device)
 
-    elif force_device is not None and force_model is None:
-
-        if force_device.isdecimal():
-            # User addressed device by its numeric selector
-            for model in models.values():
-                devices += enumerate_model(model)
-            try:
-                return [devices[int(force_device)]]
-            except IndexError:
-                logger.error(f"Invalid numeric device selector {force_device}")
-                return []
-
-        # Device is given as tty spec, so autodetect model
-        for m in [HX870, HX890]:
-            d = m(force_device)
-            if d.check_flash_id():
-                return [d]
-        else:
-            logger.warning(f"Unable to detect model listening on {force_device}. Try specifying --model.")
-            return []
-
-    elif force_device is not None and force_model is not None:
-
+    if force_device and force_device.isdecimal():
         try:
-            model = models[force_model.upper()]
-        except KeyError:
-            logger.critical(f"Invalid model specifier `{force_model}`")
+            devices = [devices[int(force_device)]]
+        except IndexError:
+            logger.error(f"Invalid numeric device selector {force_device}")
             return []
 
-        return [model(force_device)]
-
-    logger.critical("Unable to detect device")
-    return []
+    return [model(tty) for model, tty in devices]
 
 
-def enumerate_model(hx_device) -> list:
+def enumerate_devices(models: List[Type["HX870"]], force_device: Optional[str] = None) \
+        -> Iterable[Tuple[Type["HX870"], str]]:
+
+    # The numeric device selector is only applicable as index into this function's
+    # result. Therefore, we need to ignore it and generate the full list here.
+    if force_device and force_device.isdecimal():
+        force_device = None
+
+    if not force_device:
+        ports = list(list_ports.comports())
+    else:
+        ports = list(list_ports.grep(re.escape(force_device)))
+        for port in ports:
+            if force_device == port.device:
+                ports = [port]  # Limit grep result to exact match if there is one
+
+        # With both force_model and force_device used, skip auto-detection entirely
+        if len(models) == 1 and len(ports) == 1:
+            return [(models[0], ports[0].device)]
+
+        if not ports:
+            logger.error(f"Invalid device selector {force_device}")
+
+    # Auto-detect based on USB metadata (very fast)
 
     devices = []
+    for port in ports:
+        for model in models:
+            if model.usb_vendor_id is None and model.usb_product_id is None:
+                continue
+            if port.vid == model.usb_vendor_id and port.pid == model.usb_product_id:
+                devices.append((model, port.device))
+                logger.debug(f"Detected `{model.__name__}` at `{port.device}` by USB metadata")
 
-    if hx_device.usb_vendor_id is None and hx_device.usb_product_id is None:
+                if port.description != model.usb_product_name \
+                        and port.description != f"{model.usb_product_name} ({port.device})":
+                    logger.warning(f"Unexpected serial device description `{port.description}` (BE CAREFUL)")
+
+    # Auto-detect based on config magic (can be slow, skip unless necessary)
+
+    if not force_device:
+        global include_ports, exclude_ports
+        if include_ports:
+            ports = [p for p in ports if p.device in include_ports]
+        else:
+            ports = [p for p in ports if p.device not in exclude_ports]
+
+    if devices or not ports:
         return devices
 
-    for d in list_ports.comports():
-        if d.vid == hx_device.usb_vendor_id and d.pid == hx_device.usb_product_id:
-            if not d.description == hx_device.usb_product_name \
-                    and not d.description == f"{hx_device.usb_product_name} ({d.device})":
-                logger.warning(f"Unexpected serial device description `{d.description}` (BE CAREFUL)")
-            devices.append(hx_device(d.device))
+    logger.info("Probing serial ports to detect device")
+
+    baudrates = set({38400})  # Default speed to minimise probing delays
+    for model in models:
+        baudrates.add(getattr(model.protocol_model, "baudrate", 38400))
+
+    for port in ports:
+        magic = read_magic(port.device, baudrates)
+        for model in models:
+            if model.config_model.CONFIG_MAGIC == magic:
+                devices.append((model, port.device))
+                logger.debug(f"Detected `{model.__name__}` at `{port.device}` by config magic")
+                break  # Stop at first device to minimise probing delays
 
     return devices
+
+
+def read_magic(tty: str, baudrates: Set[int] = {38400}) -> int:
+    for baud in baudrates:
+        comm = ReadMagicProtocol(tty, baudrate=baud)
+        if comm.hx_hardware:
+            magic = int.from_bytes(comm.read_config_memory(0, 2), byteorder="big")
+            logger.debug(f"Read magic {magic} from `{tty}`")
+            return magic
+
+    logger.debug(f"Failed to read magic from `{tty}`")
+    return 0
 
 
 class HX870(object):

--- a/hxtool/device.py
+++ b/hxtool/device.py
@@ -2,6 +2,8 @@
 
 from logging import getLogger
 from serial.tools import list_ports
+import sys
+from typing import Iterable, Tuple, Type
 
 from .config import HX870Config, HX890Config, HX891Config, GX1400Config
 from .nmea import HX870NMEAProtocol, HX890NMEAProtocol
@@ -14,34 +16,14 @@ logger = getLogger(__name__)
 def enumerate(force_device=None, force_model=None, add_simulator=False):
 
     global models
+    model_list = models.values()
 
     devices = []
 
     if add_simulator:
-        sim = HXSimulator(HX870Config, mode="CP")
-        sim.start()
-        devices.append(HX870Sim(sim.tty))
-        sim = HXSimulator(HX870Config, mode="NMEA")
-        sim.start()
-        devices.append(HX870Sim(sim.tty))
-
-        sim = HXSimulator(HX890Config, mode="CP")
-        sim.start()
-        devices.append(HX890Sim(sim.tty))
-        sim = HXSimulator(HX890Config, mode="NMEA")
-        sim.start()
-        devices.append(HX890Sim(sim.tty))
-
-        sim = HXSimulator(HX891Config, mode="CP")
-        sim.start()
-        devices.append(HX891Sim(sim.tty))
-        sim = HXSimulator(HX891Config, mode="NMEA")
-        sim.start()
-        devices.append(HX891Sim(sim.tty))
-
-        sim = HXSimulator(GX1400Config, mode="CP")
-        sim.start()
-        devices.append(GX1400(sim.tty))
+        for model in model_list:
+            devices += model.simulators()
+        devices = [model(tty) for model, tty in devices]
 
     if force_device is None and force_model is None:
         for model in models.values():
@@ -161,6 +143,14 @@ class HX870(object):
     def check_flash_id(self, flash_id: list = None):
         return self.comm.check_flash_id(flash_id or self.config_model.FLASH_ID)
 
+    @classmethod
+    def simulators(cls) -> Iterable[Tuple[Type["HX870"], str]]:
+        sim_cls = getattr(sys.modules[__name__], cls.__name__ + "Sim")
+        for mode in "CP", "NMEA":
+            sim = HXSimulator(cls.config_model, mode)
+            sim.start()
+            yield sim_cls, sim.tty
+
     def __str__(self):
         return f"{self.brand} {self.handle} on `{self.tty} [{'CP Mode' if self.comm.cp_mode else 'NMEA Mode'}]`"
 
@@ -231,6 +221,12 @@ class GX1400(HX870):
             logger.info(f"Device on {self.tty} is {self.handle}, firmware version {fw}")
         else:
             logger.error(f"Device on {self.tty} does not behave or look like GX1400")
+
+    @classmethod
+    def simulators(cls) -> Iterable[Tuple[Type["GX1400"], str]]:
+        sim = HXSimulator(GX1400.config_model, "CP")
+        sim.start()
+        yield cls, sim.tty
 
 
 class HX870Sim(HX870):

--- a/hxtool/main.py
+++ b/hxtool/main.py
@@ -40,7 +40,7 @@ def get_args(args=None):
     parser.add_argument("-m", "--model",
                         help="force device model",
                         type=str.upper,
-                        choices=["HX870", "HX890", "GX1400"],
+                        choices=hxtool.device.models.keys(),
                         action="store")
 
     parser.add_argument("--simulator",

--- a/hxtool/protocol.py
+++ b/hxtool/protocol.py
@@ -516,6 +516,8 @@ class MediaTekProtocol(object):
 
 class GX1400Protocol(GenericHXProtocol):
 
+    baudrate = 38400
+
     def __init__(self, tty=None):
         self.conn = None
         self.connected = False
@@ -525,7 +527,7 @@ class GX1400Protocol(GenericHXProtocol):
         self.__connect(tty)
 
     def __connect(self, tty):
-        self.conn = hxtty.GenericHXTTY(tty, baudrate=38400)
+        self.conn = hxtty.GenericHXTTY(tty, baudrate=self.baudrate)
         self.connected = True
         logger.debug("Attempting GX1400 sync")
         try:
@@ -559,3 +561,23 @@ class GX1400Protocol(GenericHXProtocol):
     def get_flash_id(self):
         self.sync()
         return self.read_config_memory(0x98, 7).rstrip(b"\x00\xff").decode("ascii")
+
+
+class ReadMagicProtocol(GenericHXProtocol):
+
+    def __init__(self, tty=None, baudrate=38400):
+        self.hx_hardware = False
+        try:
+            logger.debug(f"Trying `{tty}` sync at {baudrate} baud")
+            self.conn = hxtty.GenericHXTTY(tty, baudrate=baudrate)
+            self.sync()
+            self.hx_hardware = True
+        except TimeoutError:
+            logger.debug("No response, so probably wrong baudrate or not a supported device")
+            return
+        except ProtocolError:
+            logger.debug("Unexpected response, so probably not a supported device")
+            return
+        except OSError as e:
+            logger.debug(f"OS error: {e} (ignoring, so we can look at other devices)")
+            return

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -1,0 +1,36 @@
+# -*- coding: ascii -*-
+
+import pytest
+
+from hxtool.device import enumerate
+from hxtool.simulator import HXSimulator
+from sys import platform
+
+
+@pytest.fixture(name="kill_sims")
+def kill_simulator_threads_fixture():
+    if platform.startswith("win"):
+        pytest.skip("Skipping simulator tests on Windows", allow_module_level=True)
+    yield None
+    HXSimulator.stop_instances()
+    HXSimulator.join_instances()
+
+
+def test_enumerate_all(kill_sims):
+    devices = [type(d).__name__ for d in enumerate(add_simulator=True)]
+    assert "HX870Sim" in devices
+    assert "HX890Sim" in devices
+    assert "HX891Sim" in devices
+    assert "GX1400" in devices
+    assert len(devices) == 7
+
+
+def test_enumerate_force_device(kill_sims):
+    all_devices = enumerate(add_simulator=True)
+    for i in range(len(all_devices)):
+        devices = enumerate(force_device=f"{i}", add_simulator=True)
+        assert len(devices) == 1
+        assert type(devices[0]) is type(all_devices[i])
+        assert devices[0].cp_mode == all_devices[i].cp_mode
+
+    assert not enumerate(force_device=f"{len(all_devices) + 1}", add_simulator=True)

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -2,9 +2,23 @@
 
 import pytest
 
-from hxtool.device import enumerate
+import hxtool
+from hxtool.device import enumerate, GX1400, HX870, models, read_magic
+from hxtool.protocol import GenericHXProtocol, ProtocolError
 from hxtool.simulator import HXSimulator
+import serial
 from sys import platform
+
+
+def comport(tty, meta):
+    port = serial.tools.list_ports_common.ListPortInfo(tty)
+    port.vid, port.pid, port.description = meta["vid"], meta["pid"], meta["desc"]
+    return port
+
+
+def enumerate_devices(*args):
+    devices = hxtool.device.enumerate_devices(*args)
+    return [(m.__name__, t) for m, t in devices]  # The class name is easier to test for
 
 
 @pytest.fixture(name="kill_sims")
@@ -16,6 +30,114 @@ def kill_simulator_threads_fixture():
     HXSimulator.join_instances()
 
 
+@pytest.fixture(name="monkeypatch_read_magic")
+def fixture_read_magic(monkeypatch):
+    conn = dict()
+
+    def mock_hxtty(self, tty, timeout=2, baudrate=9600):
+        conn["tty"], conn["baudrate"] = tty, baudrate
+
+    def mock_sync(self, flush_output=False, flush_input=True):
+        if conn["tty"] == "/dev/gx1400" and conn["baudrate"] != 38400:
+            raise TimeoutError
+        if conn["tty"] == "/dev/busy":
+            raise OSError
+        if conn["tty"] == "/dev/alien":
+            raise ProtocolError  # response unlike that of a Yaesu/SH device
+
+    def mock_read_config_memory(self, offset, length):
+        mock_sync(self)
+        if offset != 0 or length != 2:
+            raise NotImplementedError
+        if conn["tty"] == "/dev/hx870":
+            return b"\x03\x67"
+        if conn["tty"] == "/dev/gx1400":
+            return b"\x05\x78"
+        return b"\xff\xff"
+
+    monkeypatch.setattr(hxtool.tty.GenericHXTTY, "__init__", mock_hxtty)
+    monkeypatch.setattr(GenericHXProtocol, "sync", mock_sync)
+    monkeypatch.setattr(GenericHXProtocol, "read_config_memory", mock_read_config_memory)
+    yield None
+
+
+def test_read_magic(monkeypatch_read_magic):
+    assert read_magic("/dev/gx1400") == 1400, "GX1400: default baudrate"
+    assert read_magic("/dev/gx1400", {38400}) == 1400, "GX1400: 38400 baud"
+    assert read_magic("/dev/gx1400", {9600}) == 0, "GX1400: requires 38400 baud"
+    assert read_magic("/dev/gx1400", {4800, 9600, 19200, 38400, 57600}) == 1400, "large set"
+
+    assert read_magic("/dev/hx870", {0}) == 871, "HX870: ignores baudrate"
+    assert read_magic("/dev/hx870", {}) == 0, "empty set fails"
+
+    assert read_magic("/dev/alien") == 0, "ignores device not made by Yaesu/SH"
+    assert read_magic("/dev/busy") == 0, "ignores device that raises an OSError"
+
+
+def test_enumerate_devices(monkeypatch):
+
+    def mock_comports(links=None):
+        return [comport(tty, devices[tty]) for tty in devices.keys()]
+
+    def mock_read_magic(tty, baudrates=None):
+        return devices[tty]["magic"]
+
+    monkeypatch.setattr(serial.tools.list_ports, "comports", mock_comports)
+    monkeypatch.setattr(hxtool.device, "read_magic", mock_read_magic)
+
+    # Detection by USB metadata
+
+    devices = {
+        "/dev/gx0": dict(vid=None, pid=None, desc="GX1400", magic=1400),
+        "/dev/hx00": dict(vid=0x26aa, pid=0x10, desc="HX870", magic=871),
+        "/dev/hx0": dict(vid=0x26aa, pid=0x1e, desc="HX890", magic=890),
+        "/dev/ix0": dict(vid=0x26aa, pid=0x2e, desc="HX890", magic=891),
+    }
+
+    assert enumerate_devices(models.values(), None) == [
+        ("HX870", "/dev/hx00"),
+        ("HX890", "/dev/hx0"),
+        ("HX891", "/dev/ix0"),
+    ], "all devices with USB metadata"
+
+    assert enumerate_devices(models.values(), "/hx0") == [
+        ("HX870", "/dev/hx00"),
+        ("HX890", "/dev/hx0"),
+    ], "force_device grep match"
+
+    assert enumerate_devices(models.values(), "/dev/hx0") == [
+        ("HX890", "/dev/hx0"),
+    ], "force_device exact match"
+
+    assert enumerate_devices([HX870], "/dev/hx0") == [
+        ("HX870", "/dev/hx0"),
+    ], "force a wrong model class"  # both force_model and force_device
+
+    assert not enumerate_devices(models.values(), "blah"), "invalid force_device"
+
+    # Detection by config magic
+
+    devices = {
+        "/dev/cu.URT1": dict(vid=None, pid=None, desc="HX870", magic=871),
+        "/dev/gx0": dict(vid=None, pid=None, desc="GX1400", magic=1400),
+        "/dev/hx1": dict(vid=None, pid=None, desc="HX890", magic=891),
+    }
+
+    assert enumerate_devices([GX1400]) == [
+        ("GX1400", "/dev/gx0"),
+    ], "given model only"
+
+    assert enumerate_devices(models.values()) == [
+        ("GX1400", "/dev/gx0"),
+        ("HX891", "/dev/hx1"),
+    ], "exclude_ports: skip URT1"
+
+    hxtool.device.include_ports = ["/dev/hx1"]
+    assert enumerate_devices(models.values()) == [
+        ("HX891", "/dev/hx1"),
+    ], "include_ports: only hx1"
+
+
 def test_enumerate_all(kill_sims):
     devices = [type(d).__name__ for d in enumerate(add_simulator=True)]
     assert "HX870Sim" in devices
@@ -23,6 +145,14 @@ def test_enumerate_all(kill_sims):
     assert "HX891Sim" in devices
     assert "GX1400" in devices
     assert len(devices) == 7
+
+
+def test_enumerate_force_model(kill_sims):
+    devices = [type(d).__name__ for d in enumerate(force_model="gx1400", add_simulator=True)]
+    assert "GX1400" in devices
+    assert len(devices) == 1
+
+    assert not enumerate(force_model="GX123", add_simulator=True)
 
 
 def test_enumerate_force_device(kill_sims):
@@ -34,3 +164,10 @@ def test_enumerate_force_device(kill_sims):
         assert devices[0].cp_mode == all_devices[i].cp_mode
 
     assert not enumerate(force_device=f"{len(all_devices) + 1}", add_simulator=True)
+
+
+def test_enumerate_force_both(kill_sims):
+    devices = enumerate(force_device="0", force_model="HX891", add_simulator=True)
+    assert len(devices) == 1
+    assert type(devices[0]).__name__ == "HX891Sim"
+    assert devices[0].cp_mode


### PR DESCRIPTION
I took a swing at the device model auto-detection, as we discussed in https://github.com/cr/hx870/pull/42#issuecomment-2779659272.

This proposed change largely replaces the `enumerate()` function with new logic that’s better suited for adding new radio models, especially those lacking USB. It does so by removing hard-coded lists of model classes, and by reading config memory magic rather than the flash ID (#44).

Reading data from the device memory for identification is potentially problematic: Some devices require different baud rates than others, which can cause delays due to timeouts, and some systems have extra serial ports that raise errors. To avoid these issues, the proposed logic trusts USB metadata whenever possible, which means reading the magic is rarely even necessary. It also adds an exclusion list of OS-specific serial ports known to cause errors or timeouts.

Additionally, this change streamlines the user experience by handling the `--tty` and `--model` CLI options more consistently: Both options when given now simply restrict the auto-detection in accordance with the given values.

For example, `hxtool --model HX890` will now run the full auto-detection logic, but only consider devices identifying as HX890. This is a new feature, a rather useful one when you work with multiple device models connected at the same time. Previously, `--model` simply caused an error unless `--tty` was given, too.

As before, overriding auto-detection is possible by specifying both `--tty` and `--model`.
